### PR TITLE
Fix compiler warnings. Fixes #2

### DIFF
--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -27,8 +27,6 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 #pragma mark -
 #pragma mark VDKQueuePathEntry
 #pragma mark -
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------ */
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------ */
 
 //  This is a simple model class used to hold info about each path we watch.
 @interface VDKQueuePathEntry : NSObject
@@ -51,7 +49,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 @synthesize path = _path, watchedFD = _watchedFD, subscriptionFlags = _subscriptionFlags;
 
 
-- (id) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags;
+- (id) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags
 {
     self = [super init];
 	if (self)
@@ -94,8 +92,6 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 #pragma mark -
 #pragma mark VDKQueue
 #pragma mark -
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------ */
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------ */
 
 @interface VDKQueue ()
 - (void) watcherThread:(id)sender;
@@ -201,7 +197,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 }
 
 
-- (void) watcherThread:(id)sender;
+- (void) watcherThread:(id)sender
 {
     int					n;
     struct kevent		ev;


### PR DESCRIPTION
This just removes a few things that cause compiler warnings when the -Wall compiler flag is turned on.

Fixes #2
