### PR TITLE
Warning fixes, cleanup, and autorelease pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must ends with two \r.
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+
+### Xcode ###
+build
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcworkspace/contents.xcworkspacedata
+

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 VDKQueue
-=======
+========
 
 A modern, faster, better version of UKKQueue.
 
 <http://incident57.com/codekit>
 
-
-about
+About
 -----
 
 VDKQueue is an Objective-C wrapper around kernel queues (kQueues).
@@ -15,19 +14,17 @@ It allows you to watch a file or folder for changes and be notified when they oc
 VDKQueue is a modern, streamlined and much faster version of UKKQueue, which was originally written in 2003 by Uli Kusterer.
 Objective-C has come a long way in the past nine years and UKKQueue was long in the tooth. VDKQueue is better in several ways:
 
-	-- The number of method calls is vastly reduced.
-	-- Grand Central Dispatch is used in place of Uli's "threadProxy" notifications (much faster)
-	-- Memory footprint is roughly halved, since VDKQueue creates less overhead
-	-- Fewer locks are taken, especially in loops (faster)
-	-- The code is *much* cleaner and simpler!
-	-- There is only one .h and one .m file to include.
-	
+- The number of method calls is vastly reduced.
+- Grand Central Dispatch is used in place of Uli's "threadProxy" notifications (much faster)
+- Memory footprint is roughly halved, since VDKQueue creates less overhead
+- Fewer locks are taken, especially in loops (faster)
+- The code is *much* cleaner and simpler!
+- There is only one .h and one .m file to include.
+
 VDKQueue also fixes long-standing bugs in UKKQueue. For example: OS X limits the number of open file descriptors each process
 may have to about 3,000. If UKKQueue fails to open a new file descriptor because it has hit this limit, it will crash. VDKQueue will not.
-	
-	
-	
-performance
+
+Performance
 -----------
 
 Adding 1,945 file paths to a UKKQueue instance took, on average, 80ms. 
@@ -37,22 +34,12 @@ VDKQueue processes and pushes out notifications about file changes roughly 50-70
 
 All tests conducted on a 2008 MacBook Pro 2.5Ghz with 4GB of RAM running OS 10.7.3 using Xcode and Instruments (time profiler).
 
-	
-
-
-requirements
+Requirements
 ------------
 
-VDKQueue requires Mac OS X 10.6+ because it uses Grand Central Dispatch.
+VDKQueue requires Mac OS X 10.6+ because it uses Grand Central Dispatch. VDKQueue uses ARC.
 
-VDKQueue does not support garbage collection. If you use garbage collection, you are lazy. Shape up.
-
-VDKQueue does not currently use ARC, although it should be straightforward to convert if you wish. (Don't be the guy that can't manually manage memory, though.)
-
-
-
-
-license
+License
 -------
 
 Created by Bryan D K Jones on 28 March 2012
@@ -63,7 +50,5 @@ Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 
 This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software. Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
 
 1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-	   
 3. This notice may not be removed or altered from any source distribution.

--- a/VDKQueue.h
+++ b/VDKQueue.h
@@ -2,7 +2,7 @@
 //	Created by Bryan D K Jones on 28 March 2012
 //	Copyright 2013 Bryan D K Jones
 //
-//  Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 21 Dec 2003.
+//	Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 21 Dec 2003.
 //
 //	This software is provided 'as-is', without any express or implied
 //	warranty. In no event will the authors be held liable for any damages
@@ -10,54 +10,54 @@
 //	Permission is granted to anyone to use this software for any purpose,
 //	including commercial applications, and to alter it and redistribute it
 //	freely, subject to the following restrictions:
-//	   1. The origin of this software must not be misrepresented; you must not
-//	   claim that you wrote the original software. If you use this software
-//	   in a product, an acknowledgment in the product documentation would be
-//	   appreciated but is not required.
-//	   2. Altered source versions must be plainly marked as such, and must not be
-//	   misrepresented as being the original software.
-//	   3. This notice may not be removed or altered from any source
-//	   distribution.
+//		1. The origin of this software must not be misrepresented; you must not
+//		claim that you wrote the original software. If you use this software
+//		in a product, an acknowledgment in the product documentation would be
+//		appreciated but is not required.
+//		2. Altered source versions must be plainly marked as such, and must not be
+//		misrepresented as being the original software.
+//		3. This notice may not be removed or altered from any source
+//		distribution.
 
 //
-//  BASED ON UKKQUEUE:
+//	BASED ON UKKQUEUE:
 //
-//      This is an updated, modernized and streamlined version of the excellent UKKQueue class, which was authored by Uli Kusterer.
-//      UKKQueue was written back in 2003 and there have been many, many improvements to Objective-C since then. VDKQueue uses the 
-//      core of Uli's original class, but makes it faster and more efficient. Method calls are reduced. Grand Central Dispatch is used in place
-//      of Uli's "threadProxy" objects. The memory footprint is roughly halved, as I don't create the overhead that UKKQueue does.
+//		This is an updated, modernized and streamlined version of the excellent UKKQueue class, which was authored by Uli Kusterer.
+//		UKKQueue was written back in 2003 and there have been many, many improvements to Objective-C since then. VDKQueue uses the
+//		core of Uli's original class, but makes it faster and more efficient. Method calls are reduced. Grand Central Dispatch is used in place
+//		of Uli's "threadProxy" objects. The memory footprint is roughly halved, as I don't create the overhead that UKKQueue does.
 //
-//      VDKQueue is also simplified. The option to use it as a singleton is removed. You simply alloc/init an instance and add paths you want to
-//      watch. Your objects can be alerted to changes either by notifications or by a delegate method (or both). See below. 
+//		VDKQueue is also simplified. The option to use it as a singleton is removed. You simply alloc/init an instance and add paths you want to
+//		watch. Your objects can be alerted to changes either by notifications or by a delegate method (or both). See below.
 //
-//      It also fixes several bugs. For one, it won't crash if it can't create a file descriptor to a file you ask it to watch. (By default, an OS X process can only
-//      have about 3,000 file descriptors open at once. If you hit that limit, UKKQueue will crash. VDKQueue will not.)
-//
-
-//
-//  DEPENDENCIES: 
-//      
-//      VDKQueue requires OS 10.6+ because it relies on Grand Central Dispatch.
+//		It also fixes several bugs. For one, it won't crash if it can't create a file descriptor to a file you ask it to watch. (By default, an OS X process can only
+//		have about 3,000 file descriptors open at once. If you hit that limit, UKKQueue will crash. VDKQueue will not.)
 //
 
 //
-//  IMPORTANT NOTE ABOUT ATOMIC OPERATIONS
+//	DEPENDENCIES:
 //
-//      There are two ways of saving a file on OS X: Atomic and Non-Atomic. In a non-atomic operation, a file is saved by directly overwriting it with new data.
-//      In an Atomic save, a temporary file is first written to a different location on disk. When that completes successfully, the original file is deleted and the
-//      temporary one is renamed and moved into place where the original file existed.
+//		VDKQueue requires OS 10.6+ because it relies on Grand Central Dispatch.
 //
-//      This matters a great deal. If you tell VDKQueue to watch file X, then you save file X ATOMICALLY, you'll receive a notification about that event. HOWEVER, you will
-//      NOT receive any additional notifications for file X from then on. This is because the atomic operation has essentially created a new file that replaced the one you
-//      told VDKQueue to watch. (This is not an issue for non-atomic operations.)
+
 //
-//      To handle this, any time you receive a change notification from VDKQueue, you should call -removePath: followed by -addPath: on the file's path, even if the path
-//      has not changed. This will ensure that if the event that triggered the notification was an atomic operation, VDKQueue will start watching the "new" file that took
-//      the place of the old one.
+//	IMPORTANT NOTE ABOUT ATOMIC OPERATIONS
 //
-//      Other frameworks out there try to work around this issue by immediately attempting to re-open the file descriptor to the path. This is not bulletproof and may fail;
-//      it all depends on the timing of disk I/O. Bottom line: you could not rely on it and might miss future changes to the file path you're supposedly watching. That's why
-//      VDKQueue does not take this approach, but favors the "manual" method of "stop-watching-then-rewatch". 
+//		There are two ways of saving a file on OS X: Atomic and Non-Atomic. In a non-atomic operation, a file is saved by directly overwriting it with new data.
+//		In an Atomic save, a temporary file is first written to a different location on disk. When that completes successfully, the original file is deleted and the
+//		temporary one is renamed and moved into place where the original file existed.
+//
+//		This matters a great deal. If you tell VDKQueue to watch file X, then you save file X ATOMICALLY, you'll receive a notification about that event. HOWEVER, you will
+//		NOT receive any additional notifications for file X from then on. This is because the atomic operation has essentially created a new file that replaced the one you
+//		told VDKQueue to watch. (This is not an issue for non-atomic operations.)
+//
+//		To handle this, any time you receive a change notification from VDKQueue, you should call -removePath: followed by -addPath: on the file's path, even if the path
+//		has not changed. This will ensure that if the event that triggered the notification was an atomic operation, VDKQueue will start watching the "new" file that took
+//		the place of the old one.
+//
+//		Other frameworks out there try to work around this issue by immediately attempting to re-open the file descriptor to the path. This is not bulletproof and may fail;
+//		it all depends on the timing of disk I/O. Bottom line: you could not rely on it and might miss future changes to the file path you're supposedly watching. That's why
+//		VDKQueue does not take this approach, but favors the "manual" method of "stop-watching-then-rewatch".
 //
 
 
@@ -70,25 +70,37 @@
 // ARC Helpers
 
 #if ! __has_feature(objc_arc)
-    #define ARCCompatAutorelease(__obj__) ([__obj__ autorelease]);
-    #define ARCCompatRetain(__obj__) ([__obj__ retain]);
-    #define ARCCompatRelease(__obj__) ([__obj__ release]);
-    
-    #define ARCCompatWeakPropertyModifier assign
-    #define ARCCompatWeakPropertyTypeModifier
+#define ARCCompatAutorelease(__obj__) [__obj__ autorelease];
+#define ARCCompatRetain(__obj__) [__obj__ retain];
+#define ARCCompatRelease(__obj__) [__obj__ release];
+
+#define ARCCompatAutoreleaseInline(__obj__) [__obj__ autorelease]
+#define ARCCompatRetainInline(__obj__) [__obj__ retain]
+#define ARCCompatReleaseInline(__obj__) [__obj__ release]
+
+#define ARCCompatBridge(__type__, __obj__) __obj__
+
+#define ARCCompatWeakPropertyModifier assign
+#define ARCCompatWeakPropertyTypeModifier
 #else
-    #define ARCCompatAutorelease(__obj__) (__obj__);
-    #define ARCCompatRetain(__obj__) (__obj__);
-    #define ARCCompatRelease(__obj__) (__obj__);
-    
-    #define ARCCompatWeakPropertyModifier weak
-    #define ARCCompatWeakPropertyTypeModifier __weak
+#define ARCCompatAutorelease(__obj__)
+#define ARCCompatRetain(__obj__)
+#define ARCCompatRelease(__obj__)
+
+#define ARCCompatAutoreleaseInline(__obj__) __obj__
+#define ARCCompatRetainInline(__obj__) __obj__
+#define ARCCompatReleaseInline(__obj__) __obj__
+
+#define ARCCompatBridge(__type__, __obj__) (__bridge __type__)__obj__
+
+#define ARCCompatWeakPropertyModifier weak
+#define ARCCompatWeakPropertyTypeModifier __weak
 #endif
 
 
 //
-//  Logical OR these values into the u_int that you pass in the -addPath:notifyingAbout: method
-//  to specify the types of notifications you're interested in. Pass the default value to receive all of them.
+//	Logical OR these values into the u_int that you pass in the -addPath:notifyingAbout: method
+//	to specify the types of notifications you're interested in. Pass the default value to receive all of them.
 //
 #define VDKQueueNotifyAboutRename					NOTE_RENAME		// Item was renamed.
 #define VDKQueueNotifyAboutWrite					NOTE_WRITE		// Item contents changed (also folder contents changed).
@@ -99,14 +111,14 @@
 #define VDKQueueNotifyAboutAccessRevocation			NOTE_REVOKE		// Access to item was revoked.
 
 #define VDKQueueNotifyDefault						(VDKQueueNotifyAboutRename | VDKQueueNotifyAboutWrite \
-                                                    | VDKQueueNotifyAboutDelete | VDKQueueNotifyAboutAttributeChange \
-                                                    | VDKQueueNotifyAboutSizeIncrease | VDKQueueNotifyAboutLinkCountChanged \
-                                                    | VDKQueueNotifyAboutAccessRevocation)
+| VDKQueueNotifyAboutDelete | VDKQueueNotifyAboutAttributeChange \
+| VDKQueueNotifyAboutSizeIncrease | VDKQueueNotifyAboutLinkCountChanged \
+| VDKQueueNotifyAboutAccessRevocation)
 
 //
-//  Notifications that this class sends to the NSWORKSPACE notification center.
-//      Object          =   the instance of VDKQueue that was watching for changes
-//      userInfo.path   =   the file path where the change was observed
+//	Notifications that this class sends to the NSWORKSPACE notification center.
+//		Object			=	the instance of VDKQueue that was watching for changes
+//		userInfo.path	=	the file path where the change was observed
 //
 extern NSString * VDKQueueRenameNotification;
 extern NSString * VDKQueueWriteNotification;
@@ -119,8 +131,8 @@ extern NSString * VDKQueueAccessRevocationNotification;
 
 
 //
-//  Or, instead of subscribing to notifications, you can specify a delegate and implement this method to respond to kQueue events.
-//  Note the required statement! For speed, this class does not check to make sure the delegate implements this method. (When I say "required" I mean it!)
+//	Or, instead of subscribing to notifications, you can specify a delegate and implement this method to respond to kQueue events.
+//	Note the required statement! For speed, this class does not check to make sure the delegate implements this method. (When I say "required" I mean it!)
 //
 @class VDKQueue;
 @protocol VDKQueueDelegate <NSObject>
@@ -136,30 +148,30 @@ extern NSString * VDKQueueAccessRevocationNotification;
 
 @interface VDKQueue : NSObject
 {
-    ARCCompatWeakPropertyTypeModifier id<VDKQueueDelegate>    _delegate;
-    BOOL                    _alwaysPostNotifications;               // By default, notifications are posted only if there is no delegate set. Set this value to YES to have notes posted even when there is a delegate.
-    
+	ARCCompatWeakPropertyTypeModifier id<VDKQueueDelegate>	_delegate;
+	BOOL													_alwaysPostNotifications;				// By default, notifications are posted only if there is no delegate set. Set this value to YES to have notes posted even when there is a delegate.
+
 @private
-    int						_coreQueueFD;                           // The actual kqueue ID (Unix file descriptor).
-	NSMutableDictionary    *_watchedPathEntries;                    // List of VDKQueuePathEntries. Keys are NSStrings of the path that each VDKQueuePathEntry is for.
-    BOOL                    _keepWatcherThreadRunning;              // Set to NO to cancel the thread that watches _coreQueueFD for kQueue events
+	int														_coreQueueFD;							// The actual kqueue ID (Unix file descriptor).
+	NSMutableDictionary										*_watchedPathEntries;					// List of VDKQueuePathEntries. Keys are NSStrings of the path that each VDKQueuePathEntry is for.
+	BOOL													_keepWatcherThreadRunning;				// Set to NO to cancel the thread that watches _coreQueueFD for kQueue events
 }
 
 
 //
-//  Note: there is no need to ask whether a path is already being watched. Just add it or remove it and this class
-//        will take action only if appropriate. (Add only if we're not already watching it, remove only if we are.)
-//  
-//  Warning: You must pass full, root-relative paths. Do not pass tilde-abbreviated paths or file URLs. 
+//	Note: there is no need to ask whether a path is already being watched. Just add it or remove it and this class
+//		will take action only if appropriate. (Add only if we're not already watching it, remove only if we are.)
+//
+//	Warning: You must pass full, root-relative paths. Do not pass tilde-abbreviated paths or file URLs.
 //
 - (void) addPath:(NSString *)aPath;
-- (void) addPath:(NSString *)aPath notifyingAbout:(u_int)flags;     // See note above for values to pass in "flags"
+- (void) addPath:(NSString *)aPath notifyingAbout:(u_int)flags;		// See note above for values to pass in "flags"
 
 - (void) removePath:(NSString *)aPath;
 - (void) removeAllPaths;
 
 
-- (NSUInteger) numberOfWatchedPaths;                                //  Returns the number of paths that this VDKQueue instance is actively watching.
+- (NSUInteger) numberOfWatchedPaths;								// Returns the number of paths that this VDKQueue instance is actively watching.
 
 
 

--- a/VDKQueue.h
+++ b/VDKQueue.h
@@ -67,6 +67,25 @@
 #include <sys/event.h>
 
 
+// ARC Helpers
+
+#if ! __has_feature(objc_arc)
+    #define ARCCompatAutorelease(__obj__) ([__obj__ autorelease]);
+    #define ARCCompatRetain(__obj__) ([__obj__ retain]);
+    #define ARCCompatRelease(__obj__) ([__obj__ release]);
+    
+    #define ARCCompatWeakPropertyModifier assign
+    #define ARCCompatWeakPropertyTypeModifier
+#else
+    #define ARCCompatAutorelease(__obj__) (__obj__);
+    #define ARCCompatRetain(__obj__) (__obj__);
+    #define ARCCompatRelease(__obj__) (__obj__);
+    
+    #define ARCCompatWeakPropertyModifier weak
+    #define ARCCompatWeakPropertyTypeModifier __weak
+#endif
+
+
 //
 //  Logical OR these values into the u_int that you pass in the -addPath:notifyingAbout: method
 //  to specify the types of notifications you're interested in. Pass the default value to receive all of them.
@@ -117,7 +136,7 @@ extern NSString * VDKQueueAccessRevocationNotification;
 
 @interface VDKQueue : NSObject
 {
-    id<VDKQueueDelegate>    _delegate;
+    ARCCompatWeakPropertyTypeModifier id<VDKQueueDelegate>    _delegate;
     BOOL                    _alwaysPostNotifications;               // By default, notifications are posted only if there is no delegate set. Set this value to YES to have notes posted even when there is a delegate.
     
 @private
@@ -144,7 +163,7 @@ extern NSString * VDKQueueAccessRevocationNotification;
 
 
 
-@property (assign) id<VDKQueueDelegate> delegate;
+@property (ARCCompatWeakPropertyModifier) id<VDKQueueDelegate> delegate;
 @property (assign) BOOL alwaysPostNotifications;
 
 @end

--- a/VDKQueue.h
+++ b/VDKQueue.h
@@ -150,6 +150,7 @@ extern NSString * VDKQueueAccessRevocationNotification;
 {
 	ARCCompatWeakPropertyTypeModifier id<VDKQueueDelegate>	_delegate;
 	BOOL													_alwaysPostNotifications;				// By default, notifications are posted only if there is no delegate set. Set this value to YES to have notes posted even when there is a delegate.
+	int 													_sleepInterval;
 
 @private
 	int														_coreQueueFD;							// The actual kqueue ID (Unix file descriptor).
@@ -177,5 +178,6 @@ extern NSString * VDKQueueAccessRevocationNotification;
 
 @property (ARCCompatWeakPropertyModifier) id<VDKQueueDelegate> delegate;
 @property (assign) BOOL alwaysPostNotifications;
+@property (assign) int sleepInterval;
 
 @end

--- a/VDKQueue.h
+++ b/VDKQueue.h
@@ -1,183 +1,134 @@
-//	VDKQueue.h
-//	Created by Bryan D K Jones on 28 March 2012
-//	Copyright 2013 Bryan D K Jones
+//  VDKQueue.h
+//  Created by Bryan D K Jones on 28 March 2012
+//  Copyright 2013 Bryan D K Jones
 //
-//	Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 21 Dec 2003.
+//  Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 21 Dec 2003.
 //
-//	This software is provided 'as-is', without any express or implied
-//	warranty. In no event will the authors be held liable for any damages
-//	arising from the use of this software.
-//	Permission is granted to anyone to use this software for any purpose,
-//	including commercial applications, and to alter it and redistribute it
-//	freely, subject to the following restrictions:
-//		1. The origin of this software must not be misrepresented; you must not
-//		claim that you wrote the original software. If you use this software
-//		in a product, an acknowledgment in the product documentation would be
-//		appreciated but is not required.
-//		2. Altered source versions must be plainly marked as such, and must not be
-//		misrepresented as being the original software.
-//		3. This notice may not be removed or altered from any source
-//		distribution.
+//  This software is provided 'as-is', without any express or implied
+//  warranty. In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//      1. The origin of this software must not be misrepresented; you must not
+//      claim that you wrote the original software. If you use this software
+//      in a product, an acknowledgment in the product documentation would be
+//      appreciated but is not required.
+//      2. Altered source versions must be plainly marked as such, and must not be
+//      misrepresented as being the original software.
+//      3. This notice may not be removed or altered from any source
+//      distribution.
 
 //
-//	BASED ON UKKQUEUE:
+//  BASED ON UKKQUEUE:
 //
-//		This is an updated, modernized and streamlined version of the excellent UKKQueue class, which was authored by Uli Kusterer.
-//		UKKQueue was written back in 2003 and there have been many, many improvements to Objective-C since then. VDKQueue uses the
-//		core of Uli's original class, but makes it faster and more efficient. Method calls are reduced. Grand Central Dispatch is used in place
-//		of Uli's "threadProxy" objects. The memory footprint is roughly halved, as I don't create the overhead that UKKQueue does.
+//      This is an updated, modernized and streamlined version of the excellent UKKQueue class, which was authored by Uli Kusterer.
+//      UKKQueue was written back in 2003 and there have been many, many improvements to Objective-C since then. VDKQueue uses the
+//      core of Uli's original class, but makes it faster and more efficient. Method calls are reduced. Grand Central Dispatch is used in place
+//      of Uli's "threadProxy" objects. The memory footprint is roughly halved, as I don't create the overhead that UKKQueue does.
 //
-//		VDKQueue is also simplified. The option to use it as a singleton is removed. You simply alloc/init an instance and add paths you want to
-//		watch. Your objects can be alerted to changes either by notifications or by a delegate method (or both). See below.
+//      VDKQueue is also simplified. The option to use it as a singleton is removed. You simply alloc/init an instance and add paths you want to
+//      watch. Your objects can be alerted to changes either by notifications or by a delegate method (or both). See below.
 //
-//		It also fixes several bugs. For one, it won't crash if it can't create a file descriptor to a file you ask it to watch. (By default, an OS X process can only
-//		have about 3,000 file descriptors open at once. If you hit that limit, UKKQueue will crash. VDKQueue will not.)
-//
-
-//
-//	DEPENDENCIES:
-//
-//		VDKQueue requires OS 10.6+ because it relies on Grand Central Dispatch.
+//      It also fixes several bugs. For one, it won't crash if it can't create a file descriptor to a file you ask it to watch. (By default, an OS X process can only
+//      have about 3,000 file descriptors open at once. If you hit that limit, UKKQueue will crash. VDKQueue will not.)
 //
 
 //
-//	IMPORTANT NOTE ABOUT ATOMIC OPERATIONS
+//  DEPENDENCIES:
 //
-//		There are two ways of saving a file on OS X: Atomic and Non-Atomic. In a non-atomic operation, a file is saved by directly overwriting it with new data.
-//		In an Atomic save, a temporary file is first written to a different location on disk. When that completes successfully, the original file is deleted and the
-//		temporary one is renamed and moved into place where the original file existed.
-//
-//		This matters a great deal. If you tell VDKQueue to watch file X, then you save file X ATOMICALLY, you'll receive a notification about that event. HOWEVER, you will
-//		NOT receive any additional notifications for file X from then on. This is because the atomic operation has essentially created a new file that replaced the one you
-//		told VDKQueue to watch. (This is not an issue for non-atomic operations.)
-//
-//		To handle this, any time you receive a change notification from VDKQueue, you should call -removePath: followed by -addPath: on the file's path, even if the path
-//		has not changed. This will ensure that if the event that triggered the notification was an atomic operation, VDKQueue will start watching the "new" file that took
-//		the place of the old one.
-//
-//		Other frameworks out there try to work around this issue by immediately attempting to re-open the file descriptor to the path. This is not bulletproof and may fail;
-//		it all depends on the timing of disk I/O. Bottom line: you could not rely on it and might miss future changes to the file path you're supposedly watching. That's why
-//		VDKQueue does not take this approach, but favors the "manual" method of "stop-watching-then-rewatch".
+//      VDKQueue requires OS 10.6+ because it relies on Grand Central Dispatch.
 //
 
-
+//
+//  IMPORTANT NOTE ABOUT ATOMIC OPERATIONS
+//
+//      There are two ways of saving a file on OS X: Atomic and Non-Atomic. In a non-atomic operation, a file is saved by directly overwriting it with new data.
+//      In an Atomic save, a temporary file is first written to a different location on disk. When that completes successfully, the original file is deleted and the
+//      temporary one is renamed and moved into place where the original file existed.
+//
+//      This matters a great deal. If you tell VDKQueue to watch file X, then you save file X ATOMICALLY, you'll receive a notification about that event. HOWEVER, you will
+//      NOT receive any additional notifications for file X from then on. This is because the atomic operation has essentially created a new file that replaced the one you
+//      told VDKQueue to watch. (This is not an issue for non-atomic operations.)
+//
+//      To handle this, any time you receive a change notification from VDKQueue, you should call -removePath: followed by -addPath: on the file's path, even if the path
+//      has not changed. This will ensure that if the event that triggered the notification was an atomic operation, VDKQueue will start watching the "new" file that took
+//      the place of the old one.
+//
+//      Other frameworks out there try to work around this issue by immediately attempting to re-open the file descriptor to the path. This is not bulletproof and may fail;
+//      it all depends on the timing of disk I/O. Bottom line: you could not rely on it and might miss future changes to the file path you're supposedly watching. That's why
+//      VDKQueue does not take this approach, but favors the "manual" method of "stop-watching-then-rewatch".
+//
 
 #import <Foundation/Foundation.h>
-#include <sys/types.h>
-#include <sys/event.h>
-
-
-// ARC Helpers
-
-#if ! __has_feature(objc_arc)
-#define ARCCompatAutorelease(__obj__) [__obj__ autorelease];
-#define ARCCompatRetain(__obj__) [__obj__ retain];
-#define ARCCompatRelease(__obj__) [__obj__ release];
-
-#define ARCCompatAutoreleaseInline(__obj__) [__obj__ autorelease]
-#define ARCCompatRetainInline(__obj__) [__obj__ retain]
-#define ARCCompatReleaseInline(__obj__) [__obj__ release]
-
-#define ARCCompatBridge(__type__, __obj__) __obj__
-
-#define ARCCompatWeakPropertyModifier assign
-#define ARCCompatWeakPropertyTypeModifier
-#else
-#define ARCCompatAutorelease(__obj__)
-#define ARCCompatRetain(__obj__)
-#define ARCCompatRelease(__obj__)
-
-#define ARCCompatAutoreleaseInline(__obj__) __obj__
-#define ARCCompatRetainInline(__obj__) __obj__
-#define ARCCompatReleaseInline(__obj__) __obj__
-
-#define ARCCompatBridge(__type__, __obj__) (__bridge __type__)__obj__
-
-#define ARCCompatWeakPropertyModifier weak
-#define ARCCompatWeakPropertyTypeModifier __weak
-#endif
-
 
 //
-//	Logical OR these values into the u_int that you pass in the -addPath:notifyingAbout: method
-//	to specify the types of notifications you're interested in. Pass the default value to receive all of them.
+//  Logical OR these values into the u_int that you pass in the -addPath:notifyingAbout: method
+//  to specify the types of notifications you're interested in. Pass the default value to receive all of them.
 //
-#define VDKQueueNotifyAboutRename					NOTE_RENAME		// Item was renamed.
-#define VDKQueueNotifyAboutWrite					NOTE_WRITE		// Item contents changed (also folder contents changed).
-#define VDKQueueNotifyAboutDelete					NOTE_DELETE		// item was removed.
-#define VDKQueueNotifyAboutAttributeChange			NOTE_ATTRIB		// Item attributes changed.
-#define VDKQueueNotifyAboutSizeIncrease				NOTE_EXTEND		// Item size increased.
-#define VDKQueueNotifyAboutLinkCountChanged			NOTE_LINK		// Item's link count changed.
-#define VDKQueueNotifyAboutAccessRevocation			NOTE_REVOKE		// Access to item was revoked.
+#define VDKQueueNotifyAboutRename                   NOTE_RENAME     // Item was renamed.
+#define VDKQueueNotifyAboutWrite                    NOTE_WRITE      // Item contents changed (also folder contents changed).
+#define VDKQueueNotifyAboutDelete                   NOTE_DELETE     // item was removed.
+#define VDKQueueNotifyAboutAttributeChange          NOTE_ATTRIB     // Item attributes changed.
+#define VDKQueueNotifyAboutSizeIncrease             NOTE_EXTEND     // Item size increased.
+#define VDKQueueNotifyAboutLinkCountChanged         NOTE_LINK       // Item's link count changed.
+#define VDKQueueNotifyAboutAccessRevocation         NOTE_REVOKE     // Access to item was revoked.
 
-#define VDKQueueNotifyDefault						(VDKQueueNotifyAboutRename | VDKQueueNotifyAboutWrite \
+#define VDKQueueNotifyDefault                       (VDKQueueNotifyAboutRename | VDKQueueNotifyAboutWrite \
 | VDKQueueNotifyAboutDelete | VDKQueueNotifyAboutAttributeChange \
 | VDKQueueNotifyAboutSizeIncrease | VDKQueueNotifyAboutLinkCountChanged \
 | VDKQueueNotifyAboutAccessRevocation)
 
 //
-//	Notifications that this class sends to the NSWORKSPACE notification center.
-//		Object			=	the instance of VDKQueue that was watching for changes
-//		userInfo.path	=	the file path where the change was observed
+//  Notifications that this class sends to the NSWORKSPACE notification center.
+//      Object          =   the instance of VDKQueue that was watching for changes
+//      userInfo.path   =   the file path where the change was observed
 //
-extern NSString * VDKQueueRenameNotification;
-extern NSString * VDKQueueWriteNotification;
-extern NSString * VDKQueueDeleteNotification;
-extern NSString * VDKQueueAttributeChangeNotification;
-extern NSString * VDKQueueSizeIncreaseNotification;
-extern NSString * VDKQueueLinkCountChangeNotification;
-extern NSString * VDKQueueAccessRevocationNotification;
-
-
+extern NSString *const VDKQueueRenameNotification;
+extern NSString *const VDKQueueWriteNotification;
+extern NSString *const VDKQueueDeleteNotification;
+extern NSString *const VDKQueueAttributeChangeNotification;
+extern NSString *const VDKQueueSizeIncreaseNotification;
+extern NSString *const VDKQueueLinkCountChangeNotification;
+extern NSString *const VDKQueueAccessRevocationNotification;
 
 //
-//	Or, instead of subscribing to notifications, you can specify a delegate and implement this method to respond to kQueue events.
-//	Note the required statement! For speed, this class does not check to make sure the delegate implements this method. (When I say "required" I mean it!)
+//  Or, instead of subscribing to notifications, you can specify a delegate and implement this method to respond to kQueue events.
+//  Note the required statement! For speed, this class does not check to make sure the delegate implements this method. (When I say "required" I mean it!)
 //
+
 @class VDKQueue;
-@protocol VDKQueueDelegate <NSObject>
-@required
 
--(void) VDKQueue:(VDKQueue *)queue receivedNotification:(NSString*)noteName forPath:(NSString*)fpath;
+@protocol VDKQueueDelegate <NSObject>
+
+- (void)queue:(VDKQueue *)queue didReceiveNotification:(NSString *)notificationName forPath:(NSString *)fpath;
 
 @end
 
-
-
-
-
 @interface VDKQueue : NSObject
-{
-	ARCCompatWeakPropertyTypeModifier id<VDKQueueDelegate>	_delegate;
-	BOOL													_alwaysPostNotifications;				// By default, notifications are posted only if there is no delegate set. Set this value to YES to have notes posted even when there is a delegate.
-	NSTimeInterval											_sleepInterval;
 
-@private
-	int														_coreQueueFD;							// The actual kqueue ID (Unix file descriptor).
-	NSMutableDictionary										*_watchedPathEntries;					// List of VDKQueuePathEntries. Keys are NSStrings of the path that each VDKQueuePathEntry is for.
-	BOOL													_keepWatcherThreadRunning;				// Set to NO to cancel the thread that watches _coreQueueFD for kQueue events
-}
+/**
+ *  Note: there is no need to ask whether a path is already being watched. Just add it or remove it and this class
+ *      will take action only if appropriate. (Add only if we're not already watching it, remove only if we are.)
+ *
+ *  Warning: You must pass full, root-relative paths. Do not pass tilde-abbreviated paths or file URLs.
+ */
+- (void)addPath:(NSString *)aPath;
+/// See note above for values to pass in "flags"
+- (void)addPath:(NSString *)aPath notifyingAbout:(u_int)flags;
 
+- (void)removePath:(NSString *)aPath;
+- (void)removeAllPaths;
 
-//
-//	Note: there is no need to ask whether a path is already being watched. Just add it or remove it and this class
-//		will take action only if appropriate. (Add only if we're not already watching it, remove only if we are.)
-//
-//	Warning: You must pass full, root-relative paths. Do not pass tilde-abbreviated paths or file URLs.
-//
-- (void) addPath:(NSString *)aPath;
-- (void) addPath:(NSString *)aPath notifyingAbout:(u_int)flags;		// See note above for values to pass in "flags"
+/// Returns the number of paths that this VDKQueue instance is actively watching.
+- (NSUInteger)numberOfWatchedPaths;
 
-- (void) removePath:(NSString *)aPath;
-- (void) removeAllPaths;
-
-
-- (NSUInteger) numberOfWatchedPaths;								// Returns the number of paths that this VDKQueue instance is actively watching.
-
-
-
-@property (ARCCompatWeakPropertyModifier) id<VDKQueueDelegate> delegate;
-@property (assign) BOOL alwaysPostNotifications;
-@property (assign) NSTimeInterval sleepInterval;
+@property (nonatomic, weak) id <VDKQueueDelegate> delegate;
+/**
+ * By default, notifications are posted only if there is no delegate set.
+ * Set this value to YES to have notes posted even when there is a delegate.
+ */
+@property (nonatomic) BOOL alwaysPostNotifications;
+@property (nonatomic) NSTimeInterval sleepInterval;
 
 @end

--- a/VDKQueue.h
+++ b/VDKQueue.h
@@ -150,7 +150,7 @@ extern NSString * VDKQueueAccessRevocationNotification;
 {
 	ARCCompatWeakPropertyTypeModifier id<VDKQueueDelegate>	_delegate;
 	BOOL													_alwaysPostNotifications;				// By default, notifications are posted only if there is no delegate set. Set this value to YES to have notes posted even when there is a delegate.
-	int 													_sleepInterval;
+	NSTimeInterval											_sleepInterval;
 
 @private
 	int														_coreQueueFD;							// The actual kqueue ID (Unix file descriptor).

--- a/VDKQueue.h
+++ b/VDKQueue.h
@@ -130,6 +130,7 @@ extern NSString *const VDKQueueAccessRevocationNotification;
 @interface VDKQueue : NSObject
 
 @property (nonatomic, weak) id <VDKQueueDelegate> delegate;
+@property (nonatomic, retain) dispatch_queue_t queue;
 /**
  * By default, notifications are posted only if there is no delegate set.
  * Set this value to @c YES to have notes posted even when there is a delegate.

--- a/VDKQueue.h
+++ b/VDKQueue.h
@@ -178,6 +178,6 @@ extern NSString * VDKQueueAccessRevocationNotification;
 
 @property (ARCCompatWeakPropertyModifier) id<VDKQueueDelegate> delegate;
 @property (assign) BOOL alwaysPostNotifications;
-@property (assign) int sleepInterval;
+@property (assign) NSTimeInterval sleepInterval;
 
 @end

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -227,6 +227,8 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 	NSLog(@"watcherThread started.");
 #endif
 	
+    [[NSThread currentThread] setName:@"VDKQueue Watcher Thread"];
+    
     while(_keepWatcherThreadRunning)
     {
         @try 

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -229,109 +229,105 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 	
     while(_keepWatcherThreadRunning)
     {
-        @try 
+        @try
         {
             n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
-            if (n > 0)
+
+            if (n == 0) continue;
+
+            //NSLog( @"KEVENT returned %d", n );
+            if (ev.filter != EVFILT_VNODE) continue;
+
+            //NSLog( @"KEVENT filter is EVFILT_VNODE" );
+            if (!ev.fflags) continue;
+
+            //NSLog( @"KEVENT flags are set" );
+
+            //
+            //  Note: VDKQueue gets tested by thousands of CodeKit users who each watch several thousand files at once.
+            //        I was receiving about 3 EXC_BAD_ACCESS (SIGSEGV) crash reports a month that listed the 'path' objc_msgSend
+            //        as the culprit. That suggests the KEVENT is being sent back to us with a udata value that is NOT what we assigned
+            //        to the queue, though I don't know why and I don't know why it's intermittent. Regardless, I've added an extra
+            //        check here to try to eliminate this (infrequent) problem. In theory, a KEVENT that does not have a VDKQueuePathEntry
+            //        object attached as the udata parameter is not an event we registered for, so we should not be "missing" any events. In theory.
+            //
+            id pe = ev.udata;
+            if (!pe || ![pe respondsToSelector:@selector(path)])
+                continue;
+
+            // Need to retain so it does not disappear while the block at the bottom is waiting to run on the main thread. Released in that block.
+            NSString *fpath = [((VDKQueuePathEntry *)pe).path retain];
+            if (!fpath) continue;
+
+            [[NSWorkspace sharedWorkspace] noteFileSystemChanged:fpath];
+
+            // Clear any old notifications
+            [notesToPost removeAllObjects];
+
+            // Figure out which notifications we need to issue
+            if ((ev.fflags & NOTE_RENAME) == NOTE_RENAME)
             {
-                //NSLog( @"KEVENT returned %d", n );
-                if (ev.filter == EVFILT_VNODE)
+                [notesToPost addObject:VDKQueueRenameNotification];
+            }
+            if ((ev.fflags & NOTE_WRITE) == NOTE_WRITE)
+            {
+                [notesToPost addObject:VDKQueueWriteNotification];
+            }
+            if ((ev.fflags & NOTE_DELETE) == NOTE_DELETE)
+            {
+                [notesToPost addObject:VDKQueueDeleteNotification];
+            }
+            if ((ev.fflags & NOTE_ATTRIB) == NOTE_ATTRIB)
+            {
+                [notesToPost addObject:VDKQueueAttributeChangeNotification];
+            }
+            if ((ev.fflags & NOTE_EXTEND) == NOTE_EXTEND)
+            {
+                [notesToPost addObject:VDKQueueSizeIncreaseNotification];
+            }
+            if ((ev.fflags & NOTE_LINK) == NOTE_LINK)
+            {
+                [notesToPost addObject:VDKQueueLinkCountChangeNotification];
+            }
+            if ((ev.fflags & NOTE_REVOKE) == NOTE_REVOKE)
+            {
+                [notesToPost addObject:VDKQueueAccessRevocationNotification];
+            }
+
+            NSArray *notes = [[NSArray alloc] initWithArray:notesToPost];   // notesToPost will be changed in the next loop iteration, which will likely occur before the block below runs.
+
+            // Post the notifications (or call the delegate method) on the main thread.
+            dispatch_async(dispatch_get_main_queue(), ^{
+                for (NSString *note in notes)
                 {
-                    //NSLog( @"KEVENT filter is EVFILT_VNODE" );
-                    if (ev.fflags)
+                    [_delegate VDKQueue:self receivedNotification:note forPath:fpath];
+
+                    if (!_delegate || _alwaysPostNotifications)
                     {
-                        //NSLog( @"KEVENT flags are set" );
-                        
-                        //
-                        //  Note: VDKQueue gets tested by thousands of CodeKit users who each watch several thousand files at once.
-                        //        I was receiving about 3 EXC_BAD_ACCESS (SIGSEGV) crash reports a month that listed the 'path' objc_msgSend
-                        //        as the culprit. That suggests the KEVENT is being sent back to us with a udata value that is NOT what we assigned
-                        //        to the queue, though I don't know why and I don't know why it's intermittent. Regardless, I've added an extra
-                        //        check here to try to eliminate this (infrequent) problem. In theory, a KEVENT that does not have a VDKQueuePathEntry
-                        //        object attached as the udata parameter is not an event we registered for, so we should not be "missing" any events. In theory.
-                        //
-                        id pe = ev.udata;
-                        if (pe && [pe respondsToSelector:@selector(path)])
-                        {
-                            NSString *fpath = [((VDKQueuePathEntry *)pe).path retain];         // Need to retain so it does not disappear while the block at the bottom is waiting to run on the main thread. Released in that block.
-                            if (!fpath) continue;
-                            
-                            [[NSWorkspace sharedWorkspace] noteFileSystemChanged:fpath];
-                            
-                            // Clear any old notifications
-                            [notesToPost removeAllObjects];
-                            
-                            // Figure out which notifications we need to issue
-                            if ((ev.fflags & NOTE_RENAME) == NOTE_RENAME)
-                            {
-                                [notesToPost addObject:VDKQueueRenameNotification];
-                            }
-                            if ((ev.fflags & NOTE_WRITE) == NOTE_WRITE)
-                            {
-                                [notesToPost addObject:VDKQueueWriteNotification];
-                            }
-                            if ((ev.fflags & NOTE_DELETE) == NOTE_DELETE)
-                            {
-                                [notesToPost addObject:VDKQueueDeleteNotification];
-                            }
-                            if ((ev.fflags & NOTE_ATTRIB) == NOTE_ATTRIB)
-                            {
-                                [notesToPost addObject:VDKQueueAttributeChangeNotification];
-                            }
-                            if ((ev.fflags & NOTE_EXTEND) == NOTE_EXTEND)
-                            {
-                                [notesToPost addObject:VDKQueueSizeIncreaseNotification];
-                            }
-                            if ((ev.fflags & NOTE_LINK) == NOTE_LINK)
-                            {
-                                [notesToPost addObject:VDKQueueLinkCountChangeNotification];
-                            }
-                            if ((ev.fflags & NOTE_REVOKE) == NOTE_REVOKE)
-                            {
-                                [notesToPost addObject:VDKQueueAccessRevocationNotification];
-                            }
-                            
-                            
-                            NSArray *notes = [[NSArray alloc] initWithArray:notesToPost];   // notesToPost will be changed in the next loop iteration, which will likely occur before the block below runs.
-                            
-                            
-                            // Post the notifications (or call the delegate method) on the main thread.
-                            dispatch_async(dispatch_get_main_queue(),
-                                           ^{
-                                               for (NSString *note in notes)
-                                               {
-                                                   [_delegate VDKQueue:self receivedNotification:note forPath:fpath];
-                                                   
-                                                   if (!_delegate || _alwaysPostNotifications)
-                                                   {
-                                                       NSDictionary *userInfoDict = [[NSDictionary alloc] initWithObjectsAndKeys:fpath, @"path", nil];
-                                                       [[[NSWorkspace sharedWorkspace] notificationCenter] postNotificationName:note object:self userInfo:userInfoDict];
-                                                       [userInfoDict release];
-                                                   }
-                                               }
-                                               
-                                               [fpath release];
-                                               [notes release];
-                                           });
-                        }
+                        NSDictionary *userInfoDict = [[NSDictionary alloc] initWithObjectsAndKeys:fpath, @"path", nil];
+                        [[[NSWorkspace sharedWorkspace] notificationCenter] postNotificationName:note object:self userInfo:userInfoDict];
+                        [userInfoDict release];
                     }
                 }
-            }
+
+                [fpath release];
+                [notes release];
+            });
         }
-        
-        @catch (NSException *localException) 
+
+        @catch (NSException *localException)
         {
             NSLog(@"Error in VDKQueue watcherThread: %@", localException);
         }
     }
-    
+
 	// Close our kqueue's file descriptor
-	if(close(theFD) == -1) {
-       NSLog(@"VDKQueue watcherThread: Couldn't close main kqueue (%d)", errno); 
+	if (close(theFD) == -1) {
+       NSLog(@"VDKQueue watcherThread: Couldn't close main kqueue (%d)", errno);
     }
-    
+
     [notesToPost release];
-    
+
 #if DEBUG_LOG_THREAD_LIFETIME
 	NSLog(@"watcherThread finished.");
 #endif

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -115,7 +115,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 
 
 @implementation VDKQueue
-@synthesize delegate = _delegate, alwaysPostNotifications = _alwaysPostNotifications;
+@synthesize delegate = _delegate, alwaysPostNotifications = _alwaysPostNotifications, sleepInterval = _sleepInterval;
 
 
 
@@ -135,6 +135,11 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 		}
 
 		_alwaysPostNotifications = NO;
+#if TARGET_OS_IPHONE
+		_sleepInterval = 60;
+#else
+		_sleepInterval = 0;
+#endif
 		_watchedPathEntries = [[NSMutableDictionary alloc] init];
 	}
 	return self;
@@ -333,6 +338,9 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 		{
 			NSLog(@"Error in VDKQueue watcherThread: %@", localException);
 		}
+#if TARGET_OS_IPHONE
+		[NSThread sleepForTimeInterval:_sleepInterval];		// To save power on iOS
+#endif
 	}
 
 	// Close our kqueue's file descriptor

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -101,6 +101,8 @@ NSString *const VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevoke
         _sleepInterval = 0;
 #endif
         _watchedPathEntries = [[NSMutableDictionary alloc] init];
+
+		_queue = dispatch_get_main_queue();
     }
     return self;
 }
@@ -242,8 +244,8 @@ NSString *const VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevoke
 
                 NSArray *notes = [[NSArray alloc] initWithArray:notesToPost];   // notesToPost will be changed in the next loop iteration, which will likely occur before the block below runs.
 
-                // Post the notifications (or call the delegate method) on the main thread.
-                dispatch_async(dispatch_get_main_queue(), ^{
+                // Post the notifications (or call the delegate method) on the specified queue.
+                dispatch_async(_queue, ^{
                     for (NSString *note in notes)
                     {
                         [_delegate queue:self didReceiveNotification:note forPath:fpath];

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -1,51 +1,51 @@
-//	VDKQueue.m
-//	Created by Bryan D K Jones on 28 March 2012
-//	Copyright 2013 Bryan D K Jones
+//  VDKQueue.m
+//  Created by Bryan D K Jones on 28 March 2012
+//  Copyright 2013 Bryan D K Jones
 //
-//	Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 21 Dec 2003.
+//  Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 21 Dec 2003.
 //
-//	This software is provided 'as-is', without any express or implied
-//	warranty. In no event will the authors be held liable for any damages
-//	arising from the use of this software.
-//	Permission is granted to anyone to use this software for any purpose,
-//	including commercial applications, and to alter it and redistribute it
-//	freely, subject to the following restrictions:
-//		1. The origin of this software must not be misrepresented; you must not
-//		claim that you wrote the original software. If you use this software
-//		in a product, an acknowledgment in the product documentation would be
-//		appreciated but is not required.
-//		2. Altered source versions must be plainly marked as such, and must not be
-//		misrepresented as being the original software.
-//		3. This notice may not be removed or altered from any source
-//		distribution.
+//  This software is provided 'as-is', without any express or implied
+//  warranty. In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//      1. The origin of this software must not be misrepresented; you must not
+//      claim that you wrote the original software. If you use this software
+//      in a product, an acknowledgment in the product documentation would be
+//      appreciated but is not required.
+//      2. Altered source versions must be plainly marked as such, and must not be
+//      misrepresented as being the original software.
+//      3. This notice may not be removed or altered from any source
+//      distribution.
 
 #import "VDKQueue.h"
 #import <unistd.h>
 #import <fcntl.h>
+
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/event.h>
 
-
-
-NSString * VDKQueueRenameNotification = @"VDKQueueFileRenamedNotification";
-NSString * VDKQueueWriteNotification = @"VDKQueueFileWrittenToNotification";
-NSString * VDKQueueDeleteNotification = @"VDKQueueFileDeletedNotification";
-NSString * VDKQueueAttributeChangeNotification = @"VDKQueueFileAttributesChangedNotification";
-NSString * VDKQueueSizeIncreaseNotification = @"VDKQueueFileSizeIncreasedNotification";
-NSString * VDKQueueLinkCountChangeNotification = @"VDKQueueLinkCountChangedNotification";
-NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNotification";
+NSString *const VDKQueueRenameNotification = @"VDKQueueFileRenamedNotification";
+NSString *const VDKQueueWriteNotification = @"VDKQueueFileWrittenToNotification";
+NSString *const VDKQueueDeleteNotification = @"VDKQueueFileDeletedNotification";
+NSString *const VDKQueueAttributeChangeNotification = @"VDKQueueFileAttributesChangedNotification";
+NSString *const VDKQueueSizeIncreaseNotification = @"VDKQueueFileSizeIncreasedNotification";
+NSString *const VDKQueueLinkCountChangeNotification = @"VDKQueueLinkCountChangedNotification";
+NSString *const VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNotification";
 
 #pragma mark - VDKQueuePathEntry
 
 // This is a simple model class used to hold info about each path we watch.
 
-@interface VDKQueuePathEntry : NSObject
-{
-	NSString*		_path;
-	int				_watchedFD;
-	u_int			_subscriptionFlags;
+@interface VDKQueuePathEntry : NSObject {
+    NSString *_path;
+    int _watchedFD;
+    u_int _subscriptionFlags;
 }
 
-- (id) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags;
+- (id)initWithPath:(NSString *)inPath subscriptionFlags:(u_int)flags;
 
 @property (atomic, copy) NSString *path;
 @property (atomic, assign) int watchedFD;
@@ -54,386 +54,318 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 @end
 
 @implementation VDKQueuePathEntry
-@synthesize path = _path, watchedFD = _watchedFD, subscriptionFlags = _subscriptionFlags;
 
-
-- (id) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags
+- (id)initWithPath:(NSString *)inPath subscriptionFlags:(u_int)flags
 {
-	self = [super init];
-	if (self)
-	{
-		_path = [inPath copy];
-		_watchedFD = open([_path fileSystemRepresentation], O_EVTONLY, 0);
-		if (_watchedFD < 0)
-		{
-			ARCCompatAutorelease(self)
-			return nil;
-		}
-		_subscriptionFlags = flags;
-	}
-	return self;
+    self = [super init];
+    if (self)
+    {
+        _path = [inPath copy];
+        _watchedFD = open([_path fileSystemRepresentation], O_EVTONLY, 0);
+        if (_watchedFD < 0)
+            return nil;
+
+        _subscriptionFlags = flags;
+    }
+    return self;
 }
 
--(void)	dealloc
+- (void)dealloc
 {
-	ARCCompatRelease(_path)
-	_path = nil;
-
-	if (_watchedFD >= 0) close(_watchedFD);
-	_watchedFD = -1;
-
-#if ! __has_feature(objc_arc)
-	[super dealloc];
-#endif
+    if (_watchedFD >= 0)
+        close(_watchedFD);
+    _watchedFD = -1;
 }
 
 @end
-
-
-
-
-
-
-
-
-
-
-
 
 #pragma mark - VDKQueue
 
-@interface VDKQueue ()
-- (void) watcherThread:(id)sender;
+@interface VDKQueue () {
+    /// The actual kqueue ID (Unix file descriptor).
+    int _coreQueueFD;
+    /// List of VDKQueuePathEntries. Keys are NSStrings of the path that each VDKQueuePathEntry is for.
+    NSMutableDictionary *_watchedPathEntries;
+    /// Set to NO to cancel the thread that watches _coreQueueFD for kQueue events
+    BOOL _keepWatcherThreadRunning;
+}
+
 @end
 
-
-
 @implementation VDKQueue
-@synthesize delegate = _delegate, alwaysPostNotifications = _alwaysPostNotifications, sleepInterval = _sleepInterval;
-
-
 
 #pragma mark - INIT/DEALLOC
 
-- (id) init
+- (id)init
 {
-	self = [super init];
-	if (self)
-	{
-		_coreQueueFD = kqueue();
-		if (_coreQueueFD == -1)
-		{
-			ARCCompatAutorelease(self)
-			return nil;
-		}
+    self = [super init];
+    if (self)
+    {
+        _coreQueueFD = kqueue();
+        if (_coreQueueFD == -1)
+            return nil;
 
-		_alwaysPostNotifications = NO;
+        _alwaysPostNotifications = NO;
 #if TARGET_OS_IPHONE
-		_sleepInterval = 60;
+        _sleepInterval = 60;
 #else
-		_sleepInterval = 0;
+        _sleepInterval = 0;
 #endif
-		_watchedPathEntries = [[NSMutableDictionary alloc] init];
-	}
-	return self;
+        _watchedPathEntries = [[NSMutableDictionary alloc] init];
+    }
+    return self;
 }
 
-
-- (void) dealloc
+- (void)dealloc
 {
-	// Shut down the thread that's scanning for kQueue events
-	_keepWatcherThreadRunning = NO;
+    // Shut down the thread that's scanning for kQueue events
+    _keepWatcherThreadRunning = NO;
 
-	// Do this to close all the open file descriptors for files we're watching
-	[self removeAllPaths];
+    // Do this to close all the open file descriptors for files we're watching
+    [self removeAllPaths];
 
-	ARCCompatRelease(_watchedPathEntries)
-	_watchedPathEntries = nil;
-
-#if ! __has_feature(objc_arc)
-	[super dealloc];
-#endif
+    _watchedPathEntries = nil;
 }
-
-
-
-
 
 #pragma mark - PRIVATE METHODS
 
-- (VDKQueuePathEntry *)	addPathToQueue:(NSString *)path notifyingAbout:(u_int)flags
+- (VDKQueuePathEntry *)addPathToQueue:(NSString *)path notifyingAbout:(u_int)flags
 {
-	@synchronized(self)
-	{
-		// Are we already watching this path?
-		VDKQueuePathEntry *pathEntry = _watchedPathEntries[path];
+    @synchronized(self)
+    {
+        // Are we already watching this path?
+        VDKQueuePathEntry *pathEntry = _watchedPathEntries[path];
 
-		if (pathEntry)
-		{
-			// All flags already set?
-			if(([pathEntry subscriptionFlags] & flags) == flags)
-			{
-				return ARCCompatAutoreleaseInline( ARCCompatRetainInline(pathEntry) );
-			}
+        if (pathEntry)
+        {
+            // All flags already set?
+            if (([pathEntry subscriptionFlags] & flags) == flags)
+                return pathEntry;
 
-			flags |= [pathEntry subscriptionFlags];
-		}
+            flags |= [pathEntry subscriptionFlags];
+        }
 
-		struct timespec		nullts = { 0, 0 };
-		struct kevent		ev;
+        struct timespec     nullts = { 0, 0 };
+        struct kevent       ev;
 
-		if (!pathEntry)
-		{
-			pathEntry = ARCCompatAutoreleaseInline([[VDKQueuePathEntry alloc] initWithPath:path andSubscriptionFlags:flags]);
-		}
+        if (!pathEntry)
+            pathEntry = [[VDKQueuePathEntry alloc] initWithPath:path subscriptionFlags:flags];
 
-		if (pathEntry)
-		{
-			EV_SET(&ev, [pathEntry watchedFD], EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_CLEAR, flags, 0, ARCCompatBridge(void*, pathEntry));
+        if (pathEntry)
+        {
+            EV_SET(&ev, [pathEntry watchedFD], EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_CLEAR, flags, 0, (__bridge void *)pathEntry);
 
-			[pathEntry setSubscriptionFlags:flags];
+            [pathEntry setSubscriptionFlags:flags];
 
             _watchedPathEntries[path] = pathEntry;
             kevent(_coreQueueFD, &ev, 1, NULL, 0, &nullts);
 
-			// Start the thread that fetches and processes our events if it's not already running.
-			if(!_keepWatcherThreadRunning)
-			{
-				_keepWatcherThreadRunning = YES;
-				[NSThread detachNewThreadSelector:@selector(watcherThread:) toTarget:self withObject:nil];
-			}
-		}
+            // Start the thread that fetches and processes our events if it's not already running.
+            if (!_keepWatcherThreadRunning)
+            {
+                _keepWatcherThreadRunning = YES;
+                [NSThread detachNewThreadSelector:@selector(watcherThread:) toTarget:self withObject:nil];
+            }
+        }
 
-		return ARCCompatAutoreleaseInline( ARCCompatRetainInline(pathEntry) );
-	}
+        return pathEntry;
+    }
 
-	return nil;
+    return nil;
 }
 
-- (void) watcherThread:(id)sender
+- (void)watcherThread:(id)sender
 {
-	int					n;
-	struct kevent		ev;
-	struct timespec		timeout = { 1, 0 };		// 1 second timeout. Should be longer, but we need this thread to exit when a kqueue is dealloced, so 1 second timeout is quite a while to wait.
-	int					theFD = _coreQueueFD;	// So we don't have to risk accessing iVars when the thread is terminated.
+    int                 n;
+    struct kevent       ev;
+    struct timespec     timeout = { 1, 0 };     // 1 second timeout. Should be longer, but we need this thread to exit when a kqueue is dealloced, so 1 second timeout is quite a while to wait.
+    int                 theFD = _coreQueueFD;   // So we don't have to risk accessing iVars when the thread is terminated.
 
-	NSMutableArray		*notesToPost = [[NSMutableArray alloc] initWithCapacity:5];
+    NSMutableArray      *notesToPost = [[NSMutableArray alloc] initWithCapacity:5];
 
 #if DEBUG_LOG_THREAD_LIFETIME
-	NSLog(@"watcherThread started.");
+    NSLog(@"watcherThread started.");
 #endif
 
     [[NSThread currentThread] setName:@"VDKQueue Watcher Thread"];
 
-	while(_keepWatcherThreadRunning)
-	{
-		@try
-		{
-			n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
-			if (n > 0)
-			{
-				//NSLog( @"KEVENT returned %d", n );
-				if (ev.filter == EVFILT_VNODE)
-				{
-					//NSLog( @"KEVENT filter is EVFILT_VNODE" );
-					if (ev.fflags)
-					{
-						//NSLog( @"KEVENT flags are set" );
+    while (_keepWatcherThreadRunning)
+    {
+        @try
+        {
+            n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
+            if (n > 0)
+            {
+                //NSLog( @"KEVENT returned %d", n );
+                if (ev.filter == EVFILT_VNODE)
+                {
+                    //NSLog( @"KEVENT filter is EVFILT_VNODE" );
+                    if (ev.fflags)
+                    {
+                        //NSLog( @"KEVENT flags are set" );
 
-						//
-						//	Note: VDKQueue gets tested by thousands of CodeKit users who each watch several thousand files at once.
-						//		I was receiving about 3 EXC_BAD_ACCESS (SIGSEGV) crash reports a month that listed the 'path' objc_msgSend
-						//		as the culprit. That suggests the KEVENT is being sent back to us with a udata value that is NOT what we assigned
-						//		to the queue, though I don't know why and I don't know why it's intermittent. Regardless, I've added an extra
-						//		check here to try to eliminate this (infrequent) problem. In theory, a KEVENT that does not have a VDKQueuePathEntry
-						//		object attached as the udata parameter is not an event we registered for, so we should not be "missing" any events. In theory.
-						//
-						id pe = ARCCompatBridge(id, ev.udata);
-						if (pe && [pe respondsToSelector:@selector(path)])
-						{
-							NSString *fpath = ARCCompatRetainInline( ((VDKQueuePathEntry *)pe).path );		// Need to retain so it does not disappear while the block at the bottom is waiting to run on the main thread. Released in that block.
-							if (!fpath) continue;
+                        //
+                        //  Note: VDKQueue gets tested by thousands of CodeKit users who each watch several thousand files at once.
+                        //      I was receiving about 3 EXC_BAD_ACCESS (SIGSEGV) crash reports a month that listed the 'path' objc_msgSend
+                        //      as the culprit. That suggests the KEVENT is being sent back to us with a udata value that is NOT what we assigned
+                        //      to the queue, though I don't know why and I don't know why it's intermittent. Regardless, I've added an extra
+                        //      check here to try to eliminate this (infrequent) problem. In theory, a KEVENT that does not have a VDKQueuePathEntry
+                        //      object attached as the udata parameter is not an event we registered for, so we should not be "missing" any events. In theory.
+                        //
+                        id pe = (__bridge id)ev.udata;
+                        if (pe && [pe respondsToSelector:@selector(path)])
+                        {
+                            NSString *fpath = ((VDKQueuePathEntry *)pe).path;
+                            if (!fpath) continue;
 
                             @autoreleasepool {
-    							// Clear any old notifications
-    							[notesToPost removeAllObjects];
+                                // Clear any old notifications
+                                [notesToPost removeAllObjects];
 
-    							// Figure out which notifications we need to issue
-    							if ((ev.fflags & NOTE_RENAME) == NOTE_RENAME)
-    							{
-    								[notesToPost addObject:VDKQueueRenameNotification];
-    							}
-    							if ((ev.fflags & NOTE_WRITE) == NOTE_WRITE)
-    							{
-    								[notesToPost addObject:VDKQueueWriteNotification];
-    							}
-    							if ((ev.fflags & NOTE_DELETE) == NOTE_DELETE)
-    							{
-    								[notesToPost addObject:VDKQueueDeleteNotification];
-    							}
-    							if ((ev.fflags & NOTE_ATTRIB) == NOTE_ATTRIB)
-    							{
-    								[notesToPost addObject:VDKQueueAttributeChangeNotification];
-    							}
-    							if ((ev.fflags & NOTE_EXTEND) == NOTE_EXTEND)
-    							{
-    								[notesToPost addObject:VDKQueueSizeIncreaseNotification];
-    							}
-    							if ((ev.fflags & NOTE_LINK) == NOTE_LINK)
-    							{
-    								[notesToPost addObject:VDKQueueLinkCountChangeNotification];
-    							}
-    							if ((ev.fflags & NOTE_REVOKE) == NOTE_REVOKE)
-    							{
-    								[notesToPost addObject:VDKQueueAccessRevocationNotification];
-    							}
+                                // Figure out which notifications we need to issue
+                                if ((ev.fflags & NOTE_RENAME) == NOTE_RENAME)
+                                {
+                                    [notesToPost addObject:VDKQueueRenameNotification];
+                                }
+                                if ((ev.fflags & NOTE_WRITE) == NOTE_WRITE)
+                                {
+                                    [notesToPost addObject:VDKQueueWriteNotification];
+                                }
+                                if ((ev.fflags & NOTE_DELETE) == NOTE_DELETE)
+                                {
+                                    [notesToPost addObject:VDKQueueDeleteNotification];
+                                }
+                                if ((ev.fflags & NOTE_ATTRIB) == NOTE_ATTRIB)
+                                {
+                                    [notesToPost addObject:VDKQueueAttributeChangeNotification];
+                                }
+                                if ((ev.fflags & NOTE_EXTEND) == NOTE_EXTEND)
+                                {
+                                    [notesToPost addObject:VDKQueueSizeIncreaseNotification];
+                                }
+                                if ((ev.fflags & NOTE_LINK) == NOTE_LINK)
+                                {
+                                    [notesToPost addObject:VDKQueueLinkCountChangeNotification];
+                                }
+                                if ((ev.fflags & NOTE_REVOKE) == NOTE_REVOKE)
+                                {
+                                    [notesToPost addObject:VDKQueueAccessRevocationNotification];
+                                }
 
+                                NSArray *notes = [[NSArray alloc] initWithArray:notesToPost];   // notesToPost will be changed in the next loop iteration, which will likely occur before the block below runs.
 
-    							NSArray *notes = [[NSArray alloc] initWithArray:notesToPost];	// notesToPost will be changed in the next loop iteration, which will likely occur before the block below runs.
-
-
-    							// Post the notifications (or call the delegate method) on the main thread.
-    							dispatch_async(dispatch_get_main_queue(), ^{
+                                // Post the notifications (or call the delegate method) on the main thread.
+                                dispatch_async(dispatch_get_main_queue(), ^{
                                     for (NSString *note in notes)
                                     {
-                                        [_delegate VDKQueue:self receivedNotification:note forPath:fpath];
+                                        [_delegate queue:self didReceiveNotification:note forPath:fpath];
 
                                         if (!_delegate || _alwaysPostNotifications)
-                                        {
-                                            NSDictionary *userInfoDict = [[NSDictionary alloc] initWithObjectsAndKeys:fpath, @"path", nil];
-                                            [[NSNotificationCenter defaultCenter] postNotificationName:note object:self userInfo:userInfoDict];
-                                            ARCCompatRelease(userInfoDict)
-                                        }
+                                            [[NSNotificationCenter defaultCenter] postNotificationName:note object:self userInfo:@{@"path": fpath}];
                                     }
-                                    
-                                    ARCCompatRelease(fpath)
-                                    ARCCompatRelease(notes)
-							    });
+                                });
                             }
-						}
-					}
-				}
-			}
-		}
+                        }
+                    }
+                }
+            }
+        }
 
-		@catch (NSException *localException)
-		{
-			NSLog(@"Error in VDKQueue watcherThread: %@", localException);
-		}
+        @catch (NSException *localException)
+        {
+            NSLog(@"Error in VDKQueue watcherThread: %@", localException);
+        }
 #if TARGET_OS_IPHONE
-		[NSThread sleepForTimeInterval:_sleepInterval];		// To save power on iOS
+        [NSThread sleepForTimeInterval:_sleepInterval];     // To save power on iOS
 #endif
-	}
+    }
 
-	// Close our kqueue's file descriptor
-	if(close(theFD) == -1) {
-		NSLog(@"VDKQueue watcherThread: Couldn't close main kqueue (%d)", errno);
-	}
-
-	ARCCompatRelease(notesToPost)
+    // Close our kqueue's file descriptor
+    if (close(theFD) == -1) {
+        NSLog(@"VDKQueue watcherThread: Couldn't close main kqueue (%d)", errno);
+    }
 
 #if DEBUG_LOG_THREAD_LIFETIME
-	NSLog(@"watcherThread finished.");
+    NSLog(@"watcherThread finished.");
 #endif
-
 }
-
-
-
-
-
 
 #pragma mark - PUBLIC METHODS
 
-
-- (void) addPath:(NSString *)aPath
+- (void)addPath:(NSString *)aPath
 {
-	if (!aPath) return;
-	ARCCompatRetain(aPath)
+    if (!aPath)
+        return;
 
-	@synchronized(self)
-	{
-		VDKQueuePathEntry *entry = _watchedPathEntries[aPath];
+    @synchronized(self)
+    {
+        VDKQueuePathEntry *entry = _watchedPathEntries[aPath];
 
-		// Only add this path if we don't already have it.
-		if (!entry)
-		{
-			entry = [self addPathToQueue:aPath notifyingAbout:VDKQueueNotifyDefault];
-			if (!entry) {
-				NSLog(@"VDKQueue tried to add the path %@ to watchedPathEntries, but the VDKQueuePathEntry was nil. \nIt's possible that the host process has hit its max open file descriptors limit.", aPath);
-			}
-		}
-	}
-
-	ARCCompatRelease(aPath)
+        // Only add this path if we don't already have it.
+        if (!entry)
+        {
+            entry = [self addPathToQueue:aPath notifyingAbout:VDKQueueNotifyDefault];
+            if (!entry) {
+                NSLog(@"VDKQueue tried to add the path %@ to watchedPathEntries, but the VDKQueuePathEntry was nil. \nIt's possible that the host process has hit its max open file descriptors limit.", aPath);
+            }
+        }
+    }
 }
 
-
-- (void) addPath:(NSString *)aPath notifyingAbout:(u_int)flags
+- (void)addPath:(NSString *)aPath notifyingAbout:(u_int)flags
 {
-	if (!aPath) return;
-	ARCCompatRetain(aPath)
+    if (!aPath)
+        return;
 
-	@synchronized(self)
-	{
-		VDKQueuePathEntry *entry = _watchedPathEntries[aPath];
+    @synchronized(self)
+    {
+        VDKQueuePathEntry *entry = _watchedPathEntries[aPath];
 
-		// Only add this path if we don't already have it.
-		if (!entry)
-		{
-			entry = [self addPathToQueue:aPath notifyingAbout:flags];
-			if (!entry) {
-				NSLog(@"VDKQueue tried to add the path %@ to watchedPathEntries, but the VDKQueuePathEntry was nil. \nIt's possible that the host process has hit its max open file descriptors limit.", aPath);
-			}
-		}
-	}
-
-	ARCCompatRelease(aPath)
+        // Only add this path if we don't already have it.
+        if (!entry)
+        {
+            entry = [self addPathToQueue:aPath notifyingAbout:flags];
+            if (!entry) {
+                NSLog(@"VDKQueue tried to add the path %@ to watchedPathEntries, but the VDKQueuePathEntry was nil. \nIt's possible that the host process has hit its max open file descriptors limit.", aPath);
+            }
+        }
+    }
 }
 
-
-- (void) removePath:(NSString *)aPath
+- (void)removePath:(NSString *)aPath
 {
-	if (!aPath) return;
-	ARCCompatRetain(aPath)
+    if (!aPath)
+        return;
 
-	@synchronized(self)
-	{
-		VDKQueuePathEntry *entry = _watchedPathEntries[aPath];
+    @synchronized(self)
+    {
+        VDKQueuePathEntry *entry = _watchedPathEntries[aPath];
 
-		// Remove it only if we're watching it.
-		if (entry) {
-			[_watchedPathEntries removeObjectForKey:aPath];
-		}
-	}
-
-	ARCCompatRelease(aPath)
+        // Remove it only if we're watching it.
+        if (entry) {
+            [_watchedPathEntries removeObjectForKey:aPath];
+        }
+    }
 }
 
-
-- (void) removeAllPaths
+- (void)removeAllPaths
 {
-	@synchronized(self)
-	{
-		[_watchedPathEntries removeAllObjects];
-	}
+    @synchronized(self)
+    {
+        [_watchedPathEntries removeAllObjects];
+    }
 }
 
-
-- (NSUInteger) numberOfWatchedPaths
+- (NSUInteger)numberOfWatchedPaths
 {
-	NSUInteger count;
-	
-	@synchronized(self)
-	{
-		count = [_watchedPathEntries count];
-	}
-	
-	return count;
+    NSUInteger count;
+
+    @synchronized(self)
+    {
+        count = [_watchedPathEntries count];
+    }
+
+    return count;
 }
-
-
-
 
 @end
-

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -165,7 +165,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 	@synchronized(self)
 	{
         // Are we already watching this path?
-		VDKQueuePathEntry *pathEntry = [_watchedPathEntries objectForKey:path];
+		VDKQueuePathEntry *pathEntry = _watchedPathEntries[path];
 		
         if (pathEntry)
 		{
@@ -192,7 +192,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 			
 			[pathEntry setSubscriptionFlags:flags];
             
-            [_watchedPathEntries setObject:pathEntry forKey:path];
+            _watchedPathEntries[path] = pathEntry;
             kevent(_coreQueueFD, &ev, 1, NULL, 0, &nullts);
             
 			// Start the thread that fetches and processes our events if it's not already running.
@@ -355,7 +355,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
     
     @synchronized(self)
     {
-        VDKQueuePathEntry *entry = [_watchedPathEntries objectForKey:aPath];
+        VDKQueuePathEntry *entry = _watchedPathEntries[aPath];
         
         // Only add this path if we don't already have it.
         if (!entry)
@@ -378,7 +378,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
     
     @synchronized(self)
     {
-        VDKQueuePathEntry *entry = [_watchedPathEntries objectForKey:aPath];
+        VDKQueuePathEntry *entry = _watchedPathEntries[aPath];
         
         // Only add this path if we don't already have it.
         if (!entry)
@@ -401,7 +401,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
     
     @synchronized(self)
 	{
-		VDKQueuePathEntry *entry = [_watchedPathEntries objectForKey:aPath];
+		VDKQueuePathEntry *entry = _watchedPathEntries[aPath];
         
         // Remove it only if we're watching it.
         if (entry) {

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -2,7 +2,7 @@
 //	Created by Bryan D K Jones on 28 March 2012
 //	Copyright 2013 Bryan D K Jones
 //
-//  Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 21 Dec 2003.
+//	Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 21 Dec 2003.
 //
 //	This software is provided 'as-is', without any express or implied
 //	warranty. In no event will the authors be held liable for any damages
@@ -10,14 +10,14 @@
 //	Permission is granted to anyone to use this software for any purpose,
 //	including commercial applications, and to alter it and redistribute it
 //	freely, subject to the following restrictions:
-//	   1. The origin of this software must not be misrepresented; you must not
-//	   claim that you wrote the original software. If you use this software
-//	   in a product, an acknowledgment in the product documentation would be
-//	   appreciated but is not required.
-//	   2. Altered source versions must be plainly marked as such, and must not be
-//	   misrepresented as being the original software.
-//	   3. This notice may not be removed or altered from any source
-//	   distribution.
+//		1. The origin of this software must not be misrepresented; you must not
+//		claim that you wrote the original software. If you use this software
+//		in a product, an acknowledgment in the product documentation would be
+//		appreciated but is not required.
+//		2. Altered source versions must be plainly marked as such, and must not be
+//		misrepresented as being the original software.
+//		3. This notice may not be removed or altered from any source
+//		distribution.
 
 #import "VDKQueue.h"
 #import <unistd.h>
@@ -41,7 +41,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 #pragma mark -
 #pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-//  This is a simple model class used to hold info about each path we watch.
+//	This is a simple model class used to hold info about each path we watch.
 @interface VDKQueuePathEntry : NSObject
 {
 	NSString*		_path;
@@ -63,14 +63,14 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 
 - (id) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags;
 {
-    self = [super init];
+	self = [super init];
 	if (self)
 	{
 		_path = [inPath copy];
 		_watchedFD = open([_path fileSystemRepresentation], O_EVTONLY, 0);
 		if (_watchedFD < 0)
 		{
-            ARCCompatAutorelease(self)
+			ARCCompatAutorelease(self)
 			return nil;
 		}
 		_subscriptionFlags = flags;
@@ -82,10 +82,10 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 {
 	ARCCompatRelease(_path)
 	_path = nil;
-    
+
 	if (_watchedFD >= 0) close(_watchedFD);
 	_watchedFD = -1;
-	
+
 #if ! __has_feature(objc_arc)
 	[super dealloc];
 #endif
@@ -130,11 +130,11 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 		_coreQueueFD = kqueue();
 		if (_coreQueueFD == -1)
 		{
-            ARCCompatAutorelease(self)
+			ARCCompatAutorelease(self)
 			return nil;
 		}
-		
-        _alwaysPostNotifications = NO;
+
+		_alwaysPostNotifications = NO;
 		_watchedPathEntries = [[NSMutableDictionary alloc] init];
 	}
 	return self;
@@ -143,17 +143,17 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 
 - (void) dealloc
 {
-    // Shut down the thread that's scanning for kQueue events
-    _keepWatcherThreadRunning = NO;
-    
-    // Do this to close all the open file descriptors for files we're watching
-    [self removeAllPaths];
-    
-    ARCCompatRelease(_watchedPathEntries)
-    _watchedPathEntries = nil;
-    
+	// Shut down the thread that's scanning for kQueue events
+	_keepWatcherThreadRunning = NO;
+
+	// Do this to close all the open file descriptors for files we're watching
+	[self removeAllPaths];
+
+	ARCCompatRelease(_watchedPathEntries)
+	_watchedPathEntries = nil;
+
 #if ! __has_feature(objc_arc)
-    [super dealloc];
+	[super dealloc];
 #endif
 }
 
@@ -168,184 +168,184 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 {
 	@synchronized(self)
 	{
-        // Are we already watching this path?
+		// Are we already watching this path?
 		VDKQueuePathEntry *pathEntry = [_watchedPathEntries objectForKey:path];
-		
-        if (pathEntry)
+
+		if (pathEntry)
 		{
-            // All flags already set?
+			// All flags already set?
 			if(([pathEntry subscriptionFlags] & flags) == flags)
-            {
-                return ARCCompatAutoreleaseInline( ARCCompatReleaseInline(pathEntry) );
-            }
-			
+			{
+				return ARCCompatAutoreleaseInline( ARCCompatReleaseInline(pathEntry) );
+			}
+
 			flags |= [pathEntry subscriptionFlags];
 		}
-		
+
 		struct timespec		nullts = { 0, 0 };
 		struct kevent		ev;
-		
+
 		if (!pathEntry)
-        {
-            pathEntry = ARCCompatAutoreleaseInline([[VDKQueuePathEntry alloc] initWithPath:path andSubscriptionFlags:flags]);
-        }
-        
+		{
+			pathEntry = ARCCompatAutoreleaseInline([[VDKQueuePathEntry alloc] initWithPath:path andSubscriptionFlags:flags]);
+		}
+
 		if (pathEntry)
 		{
 			EV_SET(&ev, [pathEntry watchedFD], EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_CLEAR, flags, 0, ARCCompatBridge(void*, pathEntry));
-			
+
 			[pathEntry setSubscriptionFlags:flags];
-            
-            [_watchedPathEntries setObject:pathEntry forKey:path];
-            kevent(_coreQueueFD, &ev, 1, NULL, 0, &nullts);
-            
+
+			[_watchedPathEntries setObject:pathEntry forKey:path];
+			kevent(_coreQueueFD, &ev, 1, NULL, 0, &nullts);
+
 			// Start the thread that fetches and processes our events if it's not already running.
 			if(!_keepWatcherThreadRunning)
 			{
 				_keepWatcherThreadRunning = YES;
 				[NSThread detachNewThreadSelector:@selector(watcherThread:) toTarget:self withObject:nil];
 			}
-        }
-        
-        return ARCCompatAutoreleaseInline( ARCCompatReleaseInline(pathEntry) );
-    }
-    
-    return nil;
+		}
+
+		return ARCCompatAutoreleaseInline( ARCCompatReleaseInline(pathEntry) );
+	}
+
+	return nil;
 }
 
 
 //
-//  WARNING: This thread has no active autorelease pool, so if you make changes, you must manually manage
-//           memory without relying on autorelease. Otherwise, you will leak!
+//	WARNING: This thread has no active autorelease pool, so if you make changes, you must manually manage
+//			memory without relying on autorelease. Otherwise, you will leak!
 //
 - (void) watcherThread:(id)sender
 {
-    int					n;
-    struct kevent		ev;
-    struct timespec     timeout = { 1, 0 };     // 1 second timeout. Should be longer, but we need this thread to exit when a kqueue is dealloced, so 1 second timeout is quite a while to wait.
+	int					n;
+	struct kevent		ev;
+	struct timespec		timeout = { 1, 0 };		// 1 second timeout. Should be longer, but we need this thread to exit when a kqueue is dealloced, so 1 second timeout is quite a while to wait.
 	int					theFD = _coreQueueFD;	// So we don't have to risk accessing iVars when the thread is terminated.
-    
-    NSMutableArray      *notesToPost = [[NSMutableArray alloc] initWithCapacity:5];
-    
+
+	NSMutableArray		*notesToPost = [[NSMutableArray alloc] initWithCapacity:5];
+
 #if DEBUG_LOG_THREAD_LIFETIME
 	NSLog(@"watcherThread started.");
 #endif
-	
-    while(_keepWatcherThreadRunning)
-    {
-        @try
-        {
-            n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
-            if (n > 0)
-            {
-                //NSLog( @"KEVENT returned %d", n );
-                if (ev.filter == EVFILT_VNODE)
-                {
-                    //NSLog( @"KEVENT filter is EVFILT_VNODE" );
-                    if (ev.fflags)
-                    {
-                        //NSLog( @"KEVENT flags are set" );
-                        
-                        //
-                        //  Note: VDKQueue gets tested by thousands of CodeKit users who each watch several thousand files at once.
-                        //        I was receiving about 3 EXC_BAD_ACCESS (SIGSEGV) crash reports a month that listed the 'path' objc_msgSend
-                        //        as the culprit. That suggests the KEVENT is being sent back to us with a udata value that is NOT what we assigned
-                        //        to the queue, though I don't know why and I don't know why it's intermittent. Regardless, I've added an extra
-                        //        check here to try to eliminate this (infrequent) problem. In theory, a KEVENT that does not have a VDKQueuePathEntry
-                        //        object attached as the udata parameter is not an event we registered for, so we should not be "missing" any events. In theory.
-                        //
-                        id pe = ARCCompatBridge(id, ev.udata);
-                        if (pe && [pe respondsToSelector:@selector(path)])
-                        {
-                            NSString *fpath = ARCCompatRetainInline( ((VDKQueuePathEntry *)pe).path );         // Need to retain so it does not disappear while the block at the bottom is waiting to run on the main thread. Released in that block.
-                            if (!fpath) continue;
-                            
+
+	while(_keepWatcherThreadRunning)
+	{
+		@try
+		{
+			n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
+			if (n > 0)
+			{
+				//NSLog( @"KEVENT returned %d", n );
+				if (ev.filter == EVFILT_VNODE)
+				{
+					//NSLog( @"KEVENT filter is EVFILT_VNODE" );
+					if (ev.fflags)
+					{
+						//NSLog( @"KEVENT flags are set" );
+
+						//
+						//	Note: VDKQueue gets tested by thousands of CodeKit users who each watch several thousand files at once.
+						//		I was receiving about 3 EXC_BAD_ACCESS (SIGSEGV) crash reports a month that listed the 'path' objc_msgSend
+						//		as the culprit. That suggests the KEVENT is being sent back to us with a udata value that is NOT what we assigned
+						//		to the queue, though I don't know why and I don't know why it's intermittent. Regardless, I've added an extra
+						//		check here to try to eliminate this (infrequent) problem. In theory, a KEVENT that does not have a VDKQueuePathEntry
+						//		object attached as the udata parameter is not an event we registered for, so we should not be "missing" any events. In theory.
+						//
+						id pe = ARCCompatBridge(id, ev.udata);
+						if (pe && [pe respondsToSelector:@selector(path)])
+						{
+							NSString *fpath = ARCCompatRetainInline( ((VDKQueuePathEntry *)pe).path );		// Need to retain so it does not disappear while the block at the bottom is waiting to run on the main thread. Released in that block.
+							if (!fpath) continue;
+
 #if !TARGET_OS_IPHONE
-                            [[NSWorkspace sharedWorkspace] noteFileSystemChanged:fpath];
+							[[NSWorkspace sharedWorkspace] noteFileSystemChanged:fpath];
 #endif
-                            
-                            // Clear any old notifications
-                            [notesToPost removeAllObjects];
-                            
-                            // Figure out which notifications we need to issue
-                            if ((ev.fflags & NOTE_RENAME) == NOTE_RENAME)
-                            {
-                                [notesToPost addObject:VDKQueueRenameNotification];
-                            }
-                            if ((ev.fflags & NOTE_WRITE) == NOTE_WRITE)
-                            {
-                                [notesToPost addObject:VDKQueueWriteNotification];
-                            }
-                            if ((ev.fflags & NOTE_DELETE) == NOTE_DELETE)
-                            {
-                                [notesToPost addObject:VDKQueueDeleteNotification];
-                            }
-                            if ((ev.fflags & NOTE_ATTRIB) == NOTE_ATTRIB)
-                            {
-                                [notesToPost addObject:VDKQueueAttributeChangeNotification];
-                            }
-                            if ((ev.fflags & NOTE_EXTEND) == NOTE_EXTEND)
-                            {
-                                [notesToPost addObject:VDKQueueSizeIncreaseNotification];
-                            }
-                            if ((ev.fflags & NOTE_LINK) == NOTE_LINK)
-                            {
-                                [notesToPost addObject:VDKQueueLinkCountChangeNotification];
-                            }
-                            if ((ev.fflags & NOTE_REVOKE) == NOTE_REVOKE)
-                            {
-                                [notesToPost addObject:VDKQueueAccessRevocationNotification];
-                            }
-                            
-                            
-                            NSArray *notes = [[NSArray alloc] initWithArray:notesToPost];   // notesToPost will be changed in the next loop iteration, which will likely occur before the block below runs.
-                            
-                            
-                            // Post the notifications (or call the delegate method) on the main thread.
-                            dispatch_async(dispatch_get_main_queue(),
-                                           ^{
-                                               for (NSString *note in notes)
-                                               {
-                                                   [_delegate VDKQueue:self receivedNotification:note forPath:fpath];
-                                                   
-                                                   if (!_delegate || _alwaysPostNotifications)
-                                                   {
-                                                       NSDictionary *userInfoDict = [[NSDictionary alloc] initWithObjectsAndKeys:fpath, @"path", nil];
+
+							// Clear any old notifications
+							[notesToPost removeAllObjects];
+
+							// Figure out which notifications we need to issue
+							if ((ev.fflags & NOTE_RENAME) == NOTE_RENAME)
+							{
+								[notesToPost addObject:VDKQueueRenameNotification];
+							}
+							if ((ev.fflags & NOTE_WRITE) == NOTE_WRITE)
+							{
+								[notesToPost addObject:VDKQueueWriteNotification];
+							}
+							if ((ev.fflags & NOTE_DELETE) == NOTE_DELETE)
+							{
+								[notesToPost addObject:VDKQueueDeleteNotification];
+							}
+							if ((ev.fflags & NOTE_ATTRIB) == NOTE_ATTRIB)
+							{
+								[notesToPost addObject:VDKQueueAttributeChangeNotification];
+							}
+							if ((ev.fflags & NOTE_EXTEND) == NOTE_EXTEND)
+							{
+								[notesToPost addObject:VDKQueueSizeIncreaseNotification];
+							}
+							if ((ev.fflags & NOTE_LINK) == NOTE_LINK)
+							{
+								[notesToPost addObject:VDKQueueLinkCountChangeNotification];
+							}
+							if ((ev.fflags & NOTE_REVOKE) == NOTE_REVOKE)
+							{
+								[notesToPost addObject:VDKQueueAccessRevocationNotification];
+							}
+
+
+							NSArray *notes = [[NSArray alloc] initWithArray:notesToPost];	// notesToPost will be changed in the next loop iteration, which will likely occur before the block below runs.
+
+
+							// Post the notifications (or call the delegate method) on the main thread.
+							dispatch_async(dispatch_get_main_queue(),
+										   ^{
+											   for (NSString *note in notes)
+											   {
+												   [_delegate VDKQueue:self receivedNotification:note forPath:fpath];
+
+												   if (!_delegate || _alwaysPostNotifications)
+												   {
+													   NSDictionary *userInfoDict = [[NSDictionary alloc] initWithObjectsAndKeys:fpath, @"path", nil];
 #if TARGET_OS_IPHONE
-                                                       [[NSNotificationCenter defaultCenter] postNotificationName:note object:self userInfo:userInfoDict];
+													   [[NSNotificationCenter defaultCenter] postNotificationName:note object:self userInfo:userInfoDict];
 #else
-                                                       [[[NSWorkspace sharedWorkspace] notificationCenter] postNotificationName:note object:self userInfo:userInfoDict];
+													   [[[NSWorkspace sharedWorkspace] notificationCenter] postNotificationName:note object:self userInfo:userInfoDict];
 #endif
-                                                       ARCCompatRelease(userInfoDict)
-                                                   }
-                                               }
-                                               
-                                               ARCCompatRelease(fpath)
-                                               ARCCompatRelease(notes)
-                                           });
-                        }
-                    }
-                }
-            }
-        }
-        
-        @catch (NSException *localException)
-        {
-            NSLog(@"Error in VDKQueue watcherThread: %@", localException);
-        }
-    }
-    
+													   ARCCompatRelease(userInfoDict)
+												   }
+											   }
+
+											   ARCCompatRelease(fpath)
+											   ARCCompatRelease(notes)
+										   });
+						}
+					}
+				}
+			}
+		}
+
+		@catch (NSException *localException)
+		{
+			NSLog(@"Error in VDKQueue watcherThread: %@", localException);
+		}
+	}
+
 	// Close our kqueue's file descriptor
 	if(close(theFD) == -1) {
-        NSLog(@"VDKQueue watcherThread: Couldn't close main kqueue (%d)", errno);
-    }
-    
-    ARCCompatRelease(notesToPost)
-    
+		NSLog(@"VDKQueue watcherThread: Couldn't close main kqueue (%d)", errno);
+	}
+
+	ARCCompatRelease(notesToPost)
+
 #if DEBUG_LOG_THREAD_LIFETIME
 	NSLog(@"watcherThread finished.");
 #endif
-    
+
 }
 
 
@@ -360,88 +360,88 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 
 - (void) addPath:(NSString *)aPath
 {
-    if (!aPath) return;
-    ARCCompatRetain(aPath)
-    
-    @synchronized(self)
-    {
-        VDKQueuePathEntry *entry = [_watchedPathEntries objectForKey:aPath];
-        
-        // Only add this path if we don't already have it.
-        if (!entry)
-        {
-            entry = [self addPathToQueue:aPath notifyingAbout:VDKQueueNotifyDefault];
-            if (!entry) {
-                NSLog(@"VDKQueue tried to add the path %@ to watchedPathEntries, but the VDKQueuePathEntry was nil. \nIt's possible that the host process has hit its max open file descriptors limit.", aPath);
-            }
-        }
-    }
-    
-    ARCCompatRelease(aPath)
+	if (!aPath) return;
+	ARCCompatRetain(aPath)
+
+	@synchronized(self)
+	{
+		VDKQueuePathEntry *entry = [_watchedPathEntries objectForKey:aPath];
+
+		// Only add this path if we don't already have it.
+		if (!entry)
+		{
+			entry = [self addPathToQueue:aPath notifyingAbout:VDKQueueNotifyDefault];
+			if (!entry) {
+				NSLog(@"VDKQueue tried to add the path %@ to watchedPathEntries, but the VDKQueuePathEntry was nil. \nIt's possible that the host process has hit its max open file descriptors limit.", aPath);
+			}
+		}
+	}
+
+	ARCCompatRelease(aPath)
 }
 
 
 - (void) addPath:(NSString *)aPath notifyingAbout:(u_int)flags
 {
-    if (!aPath) return;
-    ARCCompatRetain(aPath)
-    
-    @synchronized(self)
-    {
-        VDKQueuePathEntry *entry = [_watchedPathEntries objectForKey:aPath];
-        
-        // Only add this path if we don't already have it.
-        if (!entry)
-        {
-            entry = [self addPathToQueue:aPath notifyingAbout:flags];
-            if (!entry) {
-                NSLog(@"VDKQueue tried to add the path %@ to watchedPathEntries, but the VDKQueuePathEntry was nil. \nIt's possible that the host process has hit its max open file descriptors limit.", aPath);
-            }
-        }
-    }
-    
-    ARCCompatRelease(aPath)
+	if (!aPath) return;
+	ARCCompatRetain(aPath)
+
+	@synchronized(self)
+	{
+		VDKQueuePathEntry *entry = [_watchedPathEntries objectForKey:aPath];
+
+		// Only add this path if we don't already have it.
+		if (!entry)
+		{
+			entry = [self addPathToQueue:aPath notifyingAbout:flags];
+			if (!entry) {
+				NSLog(@"VDKQueue tried to add the path %@ to watchedPathEntries, but the VDKQueuePathEntry was nil. \nIt's possible that the host process has hit its max open file descriptors limit.", aPath);
+			}
+		}
+	}
+
+	ARCCompatRelease(aPath)
 }
 
 
 - (void) removePath:(NSString *)aPath
 {
-    if (!aPath) return;
-    ARCCompatRetain(aPath)
-    
-    @synchronized(self)
+	if (!aPath) return;
+	ARCCompatRetain(aPath)
+
+	@synchronized(self)
 	{
 		VDKQueuePathEntry *entry = [_watchedPathEntries objectForKey:aPath];
-        
-        // Remove it only if we're watching it.
-        if (entry) {
-            [_watchedPathEntries removeObjectForKey:aPath];
-        }
+
+		// Remove it only if we're watching it.
+		if (entry) {
+			[_watchedPathEntries removeObjectForKey:aPath];
+		}
 	}
-    
-    ARCCompatRelease(aPath)
+
+	ARCCompatRelease(aPath)
 }
 
 
 - (void) removeAllPaths
 {
-    @synchronized(self)
-    {
-        [_watchedPathEntries removeAllObjects];
-    }
+	@synchronized(self)
+	{
+		[_watchedPathEntries removeAllObjects];
+	}
 }
 
 
 - (NSUInteger) numberOfWatchedPaths
 {
-    NSUInteger count;
-    
-    @synchronized(self)
-    {
-        count = [_watchedPathEntries count];
-    }
-    
-    return count;
+	NSUInteger count;
+	
+	@synchronized(self)
+	{
+		count = [_watchedPathEntries count];
+	}
+	
+	return count;
 }
 
 

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -233,6 +233,12 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
         {
             n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
 
+            if (n == -1)
+            {
+                NSLog(@"watcherThread: kevent returned error %d: %s", errno, strerror(errno));
+                break;
+            }
+
             if (n == 0) continue;
 
             //NSLog( @"KEVENT returned %d", n );

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -39,7 +39,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 #pragma mark -
 #pragma mark VDKQueuePathEntry
 #pragma mark -
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------
+#pragma mark ------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 //  This is a simple model class used to hold info about each path we watch.
 @interface VDKQueuePathEntry : NSObject
@@ -61,7 +61,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 @synthesize path = _path, watchedFD = _watchedFD, subscriptionFlags = _subscriptionFlags;
 
 
-- (id) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags;
+- (id) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags
 {
     self = [super init];
 	if (self)
@@ -104,7 +104,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 #pragma mark -
 #pragma mark VDKQueue
 #pragma mark -
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------
+#pragma mark ------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 @interface VDKQueue ()
 - (void) watcherThread:(id)sender;
@@ -345,7 +345,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 
 #pragma mark -
 #pragma mark PUBLIC METHODS
-#pragma -----------------------------------------------------------------------------------------------------------------------------------------------------
+#pragma mark -----------------------------------------------------------------------------------------------------------------------------------------------------
 
 
 - (void) addPath:(NSString *)aPath

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -22,13 +22,7 @@ NSString * VDKQueueSizeIncreaseNotification = @"VDKQueueFileSizeIncreasedNotific
 NSString * VDKQueueLinkCountChangeNotification = @"VDKQueueLinkCountChangedNotification";
 NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNotification";
 
-
-
-#pragma mark -
 #pragma mark VDKQueuePathEntry
-#pragma mark -
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------ */
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------ */
 
 //  This is a simple model class used to hold info about each path we watch.
 @interface VDKQueuePathEntry : NSObject
@@ -91,11 +85,8 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 
 
 
-#pragma mark -
+
 #pragma mark VDKQueue
-#pragma mark -
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------ */
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------ */
 
 @interface VDKQueue ()
 - (void) watcherThread:(id)sender;

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -256,8 +256,6 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
                             NSString *fpath = [((VDKQueuePathEntry *)pe).path retain];         // Need to retain so it does not disappear while the block at the bottom is waiting to run on the main thread. Released in that block.
                             if (!fpath) continue;
                             
-                            [[NSWorkspace sharedWorkspace] noteFileSystemChanged:fpath];
-                            
                             // Clear any old notifications
                             [notesToPost removeAllObjects];
                             
@@ -305,7 +303,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
                                                    if (!_delegate || _alwaysPostNotifications)
                                                    {
                                                        NSDictionary *userInfoDict = [[NSDictionary alloc] initWithObjectsAndKeys:fpath, @"path", nil];
-                                                       [[[NSWorkspace sharedWorkspace] notificationCenter] postNotificationName:note object:self userInfo:userInfoDict];
+                                                       [[NSNotificationCenter defaultCenter] postNotificationName:note object:self userInfo:userInfoDict];
                                                        [userInfoDict release];
                                                    }
                                                }

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -176,7 +176,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 			// All flags already set?
 			if(([pathEntry subscriptionFlags] & flags) == flags)
 			{
-				return ARCCompatAutoreleaseInline( ARCCompatReleaseInline(pathEntry) );
+				return ARCCompatAutoreleaseInline( ARCCompatRetainInline(pathEntry) );
 			}
 
 			flags |= [pathEntry subscriptionFlags];
@@ -207,7 +207,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 			}
 		}
 
-		return ARCCompatAutoreleaseInline( ARCCompatReleaseInline(pathEntry) );
+		return ARCCompatAutoreleaseInline( ARCCompatRetainInline(pathEntry) );
 	}
 
 	return nil;


### PR DESCRIPTION
This removes the remaining warnings I can see in VDKQueue, as well as some general cleanup.

I also had to add an autorelease pool, because now that the system frameworks are built using ARC, we're getting back autoreleased objects which will be leaked.
