### PR TITLE
unifying tabs and spaces

### DIFF
--- a/VDKQueue.h
+++ b/VDKQueue.h
@@ -1,42 +1,42 @@
-//	VDKQueue.h
-//	Created by Bryan D K Jones on 28 March 2012
-//	Copyright 2013 Bryan D K Jones
+//    VDKQueue.h
+//    Created by Bryan D K Jones on 28 March 2012
+//    Copyright 2013 Bryan D K Jones
 //
 //  Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 21 Dec 2003.
 //
-//	This software is provided 'as-is', without any express or implied
-//	warranty. In no event will the authors be held liable for any damages
-//	arising from the use of this software.
-//	Permission is granted to anyone to use this software for any purpose,
-//	including commercial applications, and to alter it and redistribute it
-//	freely, subject to the following restrictions:
-//	   1. The origin of this software must not be misrepresented; you must not
-//	   claim that you wrote the original software. If you use this software
-//	   in a product, an acknowledgment in the product documentation would be
-//	   appreciated but is not required.
-//	   2. Altered source versions must be plainly marked as such, and must not be
-//	   misrepresented as being the original software.
-//	   3. This notice may not be removed or altered from any source
-//	   distribution.
+//    This software is provided 'as-is', without any express or implied
+//    warranty. In no event will the authors be held liable for any damages
+//    arising from the use of this software.
+//    Permission is granted to anyone to use this software for any purpose,
+//    including commercial applications, and to alter it and redistribute it
+//    freely, subject to the following restrictions:
+//       1. The origin of this software must not be misrepresented; you must not
+//       claim that you wrote the original software. If you use this software
+//       in a product, an acknowledgment in the product documentation would be
+//       appreciated but is not required.
+//       2. Altered source versions must be plainly marked as such, and must not be
+//       misrepresented as being the original software.
+//       3. This notice may not be removed or altered from any source
+//       distribution.
 
 //
 //  BASED ON UKKQUEUE:
 //
 //      This is an updated, modernized and streamlined version of the excellent UKKQueue class, which was authored by Uli Kusterer.
-//      UKKQueue was written back in 2003 and there have been many, many improvements to Objective-C since then. VDKQueue uses the 
+//      UKKQueue was written back in 2003 and there have been many, many improvements to Objective-C since then. VDKQueue uses the
 //      core of Uli's original class, but makes it faster and more efficient. Method calls are reduced. Grand Central Dispatch is used in place
 //      of Uli's "threadProxy" objects. The memory footprint is roughly halved, as I don't create the overhead that UKKQueue does.
 //
 //      VDKQueue is also simplified. The option to use it as a singleton is removed. You simply alloc/init an instance and add paths you want to
-//      watch. Your objects can be alerted to changes either by notifications or by a delegate method (or both). See below. 
+//      watch. Your objects can be alerted to changes either by notifications or by a delegate method (or both). See below.
 //
 //      It also fixes several bugs. For one, it won't crash if it can't create a file descriptor to a file you ask it to watch. (By default, an OS X process can only
 //      have about 3,000 file descriptors open at once. If you hit that limit, UKKQueue will crash. VDKQueue will not.)
 //
 
 //
-//  DEPENDENCIES: 
-//      
+//  DEPENDENCIES:
+//
 //      VDKQueue requires OS 10.6+ because it relies on Grand Central Dispatch.
 //
 
@@ -57,7 +57,7 @@
 //
 //      Other frameworks out there try to work around this issue by immediately attempting to re-open the file descriptor to the path. This is not bulletproof and may fail;
 //      it all depends on the timing of disk I/O. Bottom line: you could not rely on it and might miss future changes to the file path you're supposedly watching. That's why
-//      VDKQueue does not take this approach, but favors the "manual" method of "stop-watching-then-rewatch". 
+//      VDKQueue does not take this approach, but favors the "manual" method of "stop-watching-then-rewatch".
 //
 
 
@@ -71,15 +71,15 @@
 //  Logical OR these values into the u_int that you pass in the -addPath:notifyingAbout: method
 //  to specify the types of notifications you're interested in. Pass the default value to receive all of them.
 //
-#define VDKQueueNotifyAboutRename					NOTE_RENAME		// Item was renamed.
-#define VDKQueueNotifyAboutWrite					NOTE_WRITE		// Item contents changed (also folder contents changed).
-#define VDKQueueNotifyAboutDelete					NOTE_DELETE		// item was removed.
-#define VDKQueueNotifyAboutAttributeChange			NOTE_ATTRIB		// Item attributes changed.
-#define VDKQueueNotifyAboutSizeIncrease				NOTE_EXTEND		// Item size increased.
-#define VDKQueueNotifyAboutLinkCountChanged			NOTE_LINK		// Item's link count changed.
-#define VDKQueueNotifyAboutAccessRevocation			NOTE_REVOKE		// Access to item was revoked.
+#define VDKQueueNotifyAboutRename                    NOTE_RENAME        // Item was renamed.
+#define VDKQueueNotifyAboutWrite                    NOTE_WRITE        // Item contents changed (also folder contents changed).
+#define VDKQueueNotifyAboutDelete                    NOTE_DELETE        // item was removed.
+#define VDKQueueNotifyAboutAttributeChange            NOTE_ATTRIB        // Item attributes changed.
+#define VDKQueueNotifyAboutSizeIncrease                NOTE_EXTEND        // Item size increased.
+#define VDKQueueNotifyAboutLinkCountChanged            NOTE_LINK        // Item's link count changed.
+#define VDKQueueNotifyAboutAccessRevocation            NOTE_REVOKE        // Access to item was revoked.
 
-#define VDKQueueNotifyDefault						(VDKQueueNotifyAboutRename | VDKQueueNotifyAboutWrite \
+#define VDKQueueNotifyDefault                        (VDKQueueNotifyAboutRename | VDKQueueNotifyAboutWrite \
                                                     | VDKQueueNotifyAboutDelete | VDKQueueNotifyAboutAttributeChange \
                                                     | VDKQueueNotifyAboutSizeIncrease | VDKQueueNotifyAboutLinkCountChanged \
                                                     | VDKQueueNotifyAboutAccessRevocation)
@@ -107,10 +107,9 @@ extern NSString * VDKQueueAccessRevocationNotification;
 @protocol VDKQueueDelegate <NSObject>
 @required
 
--(void) VDKQueue:(VDKQueue *)queue receivedNotification:(NSString*)noteName forPath:(NSString*)fpath;
+- (void) VDKQueue:(VDKQueue *)queue receivedNotification:(NSString*)noteName forPath:(NSString*)fpath;
 
 @end
-
 
 
 
@@ -121,8 +120,8 @@ extern NSString * VDKQueueAccessRevocationNotification;
     BOOL                    _alwaysPostNotifications;               // By default, notifications are posted only if there is no delegate set. Set this value to YES to have notes posted even when there is a delegate.
     
 @private
-    int						_coreQueueFD;                           // The actual kqueue ID (Unix file descriptor).
-	NSMutableDictionary    *_watchedPathEntries;                    // List of VDKQueuePathEntries. Keys are NSStrings of the path that each VDKQueuePathEntry is for.
+    int                        _coreQueueFD;                           // The actual kqueue ID (Unix file descriptor).
+    NSMutableDictionary    *_watchedPathEntries;                    // List of VDKQueuePathEntries. Keys are NSStrings of the path that each VDKQueuePathEntry is for.
     BOOL                    _keepWatcherThreadRunning;              // Set to NO to cancel the thread that watches _coreQueueFD for kQueue events
 }
 
@@ -130,8 +129,8 @@ extern NSString * VDKQueueAccessRevocationNotification;
 //
 //  Note: there is no need to ask whether a path is already being watched. Just add it or remove it and this class
 //        will take action only if appropriate. (Add only if we're not already watching it, remove only if we are.)
-//  
-//  Warning: You must pass full, root-relative paths. Do not pass tilde-abbreviated paths or file URLs. 
+//
+//  Warning: You must pass full, root-relative paths. Do not pass tilde-abbreviated paths or file URLs.
 //
 - (void) addPath:(NSString *)aPath;
 - (void) addPath:(NSString *)aPath notifyingAbout:(u_int)flags;     // See note above for values to pass in "flags"

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -1,23 +1,23 @@
-//	VDKQueue.m
-//	Created by Bryan D K Jones on 28 March 2012
-//	Copyright 2013 Bryan D K Jones
+//    VDKQueue.m
+//    Created by Bryan D K Jones on 28 March 2012
+//    Copyright 2013 Bryan D K Jones
 //
 //  Based heavily on UKKQueue, which was created and copyrighted by Uli Kusterer on 21 Dec 2003.
 //
-//	This software is provided 'as-is', without any express or implied
-//	warranty. In no event will the authors be held liable for any damages
-//	arising from the use of this software.
-//	Permission is granted to anyone to use this software for any purpose,
-//	including commercial applications, and to alter it and redistribute it
-//	freely, subject to the following restrictions:
-//	   1. The origin of this software must not be misrepresented; you must not
-//	   claim that you wrote the original software. If you use this software
-//	   in a product, an acknowledgment in the product documentation would be
-//	   appreciated but is not required.
-//	   2. Altered source versions must be plainly marked as such, and must not be
-//	   misrepresented as being the original software.
-//	   3. This notice may not be removed or altered from any source
-//	   distribution.
+//    This software is provided 'as-is', without any express or implied
+//    warranty. In no event will the authors be held liable for any damages
+//    arising from the use of this software.
+//    Permission is granted to anyone to use this software for any purpose,
+//    including commercial applications, and to alter it and redistribute it
+//    freely, subject to the following restrictions:
+//       1. The origin of this software must not be misrepresented; you must not
+//       claim that you wrote the original software. If you use this software
+//       in a product, an acknowledgment in the product documentation would be
+//       appreciated but is not required.
+//       2. Altered source versions must be plainly marked as such, and must not be
+//       misrepresented as being the original software.
+//       3. This notice may not be removed or altered from any source
+//       distribution.
 
 #import "VDKQueue.h"
 #import <unistd.h>
@@ -39,14 +39,14 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 #pragma mark -
 #pragma mark VDKQueuePathEntry
 #pragma mark -
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------
+#pragma -----------------------------------------------------------------------
 
 //  This is a simple model class used to hold info about each path we watch.
 @interface VDKQueuePathEntry : NSObject
 {
-	NSString*		_path;
-	int				_watchedFD;
-	u_int			_subscriptionFlags;
+    NSString*        _path;
+    int                _watchedFD;
+    u_int            _subscriptionFlags;
 }
 
 - (id) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags;
@@ -61,32 +61,32 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 @synthesize path = _path, watchedFD = _watchedFD, subscriptionFlags = _subscriptionFlags;
 
 
-- (id) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags;
+- (id) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags
 {
     self = [super init];
-	if (self)
-	{
-		_path = [inPath copy];
-		_watchedFD = open([_path fileSystemRepresentation], O_EVTONLY, 0);
-		if (_watchedFD < 0)
-		{
-			[self autorelease];
-			return nil;
-		}
-		_subscriptionFlags = flags;
-	}
-	return self;
+    if (self)
+    {
+        _path = [inPath copy];
+        _watchedFD = open([_path fileSystemRepresentation], O_EVTONLY, 0);
+        if (_watchedFD < 0)
+        {
+            [self autorelease];
+            return nil;
+        }
+        _subscriptionFlags = flags;
+    }
+    return self;
 }
 
--(void)	dealloc
+- (void) dealloc
 {
-	[_path release];
-	_path = nil;
+    [_path release];
+    _path = nil;
     
-	if (_watchedFD >= 0) close(_watchedFD);
-	_watchedFD = -1;
-	
-	[super dealloc];
+    if (_watchedFD >= 0) close(_watchedFD);
+    _watchedFD = -1;
+    
+    [super dealloc];
 }
 
 @end
@@ -94,17 +94,10 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 
 
 
-
-
-
-
-
-
-
 #pragma mark -
 #pragma mark VDKQueue
 #pragma mark -
-#pragma ------------------------------------------------------------------------------------------------------------------------------------------------------------
+#pragma -----------------------------------------------------------------------
 
 @interface VDKQueue ()
 - (void) watcherThread:(id)sender;
@@ -122,20 +115,20 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 
 - (id) init
 {
-	self = [super init];
-	if (self)
-	{
-		_coreQueueFD = kqueue();
-		if (_coreQueueFD == -1)
-		{
-			[self autorelease];
-			return nil;
-		}
-		
+    self = [super init];
+    if (self)
+    {
+        _coreQueueFD = kqueue();
+        if (_coreQueueFD == -1)
+        {
+            [self autorelease];
+            return nil;
+        }
+        
         _alwaysPostNotifications = NO;
-		_watchedPathEntries = [[NSMutableDictionary alloc] init];
-	}
-	return self;
+        _watchedPathEntries = [[NSMutableDictionary alloc] init];
+    }
+    return self;
 }
 
 
@@ -156,51 +149,50 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 
 
 
-
 #pragma mark -
 #pragma mark PRIVATE METHODS
 
-- (VDKQueuePathEntry *)	addPathToQueue:(NSString *)path notifyingAbout:(u_int)flags
+- (VDKQueuePathEntry *) addPathToQueue:(NSString *)path notifyingAbout:(u_int)flags
 {
-	@synchronized(self)
-	{
+    @synchronized(self)
+    {
         // Are we already watching this path?
-		VDKQueuePathEntry *pathEntry = [_watchedPathEntries objectForKey:path];
-		
+        VDKQueuePathEntry *pathEntry = [_watchedPathEntries objectForKey:path];
+        
         if (pathEntry)
-		{
+        {
             // All flags already set?
-			if(([pathEntry subscriptionFlags] & flags) == flags) 
+            if (([pathEntry subscriptionFlags] & flags) == flags)
             {
-				return [[pathEntry retain] autorelease]; 
+                return [[pathEntry retain] autorelease];
             }
-			
-			flags |= [pathEntry subscriptionFlags];
-		}
-		
-		struct timespec		nullts = { 0, 0 };
-		struct kevent		ev;
-		
-		if (!pathEntry)
+            
+            flags |= [pathEntry subscriptionFlags];
+        }
+        
+        struct timespec        nullts = { 0, 0 };
+        struct kevent        ev;
+        
+        if (!pathEntry)
         {
             pathEntry = [[[VDKQueuePathEntry alloc] initWithPath:path andSubscriptionFlags:flags] autorelease];
         }
         
-		if (pathEntry)
-		{
-			EV_SET(&ev, [pathEntry watchedFD], EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_CLEAR, flags, 0, pathEntry);
-			
-			[pathEntry setSubscriptionFlags:flags];
+        if (pathEntry)
+        {
+            EV_SET(&ev, [pathEntry watchedFD], EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_CLEAR, flags, 0, pathEntry);
+            
+            [pathEntry setSubscriptionFlags:flags];
             
             [_watchedPathEntries setObject:pathEntry forKey:path];
             kevent(_coreQueueFD, &ev, 1, NULL, 0, &nullts);
             
-			// Start the thread that fetches and processes our events if it's not already running.
-			if(!_keepWatcherThreadRunning)
-			{
-				_keepWatcherThreadRunning = YES;
-				[NSThread detachNewThreadSelector:@selector(watcherThread:) toTarget:self withObject:nil];
-			}
+            // Start the thread that fetches and processes our events if it's not already running.
+            if (!_keepWatcherThreadRunning)
+            {
+                _keepWatcherThreadRunning = YES;
+                [NSThread detachNewThreadSelector:@selector(watcherThread:) toTarget:self withObject:nil];
+            }
         }
         
         return [[pathEntry retain] autorelease];
@@ -211,25 +203,25 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 
 
 //
-//  WARNING: This thread has no active autorelease pool, so if you make changes, you must manually manage 
+//  WARNING: This thread has no active autorelease pool, so if you make changes, you must manually manage
 //           memory without relying on autorelease. Otherwise, you will leak!
 //
 - (void) watcherThread:(id)sender
 {
-    int					n;
-    struct kevent		ev;
+    int                    n;
+    struct kevent        ev;
     struct timespec     timeout = { 1, 0 };     // 1 second timeout. Should be longer, but we need this thread to exit when a kqueue is dealloced, so 1 second timeout is quite a while to wait.
-	int					theFD = _coreQueueFD;	// So we don't have to risk accessing iVars when the thread is terminated.
+    int                    theFD = _coreQueueFD;    // So we don't have to risk accessing iVars when the thread is terminated.
     
     NSMutableArray      *notesToPost = [[NSMutableArray alloc] initWithCapacity:5];
     
 #if DEBUG_LOG_THREAD_LIFETIME
-	NSLog(@"watcherThread started.");
+    NSLog(@"watcherThread started.");
 #endif
-	
-    while(_keepWatcherThreadRunning)
+    
+    while (_keepWatcherThreadRunning)
     {
-        @try 
+        @try
         {
             n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
             if (n > 0)
@@ -319,33 +311,30 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
             }
         }
         
-        @catch (NSException *localException) 
+        @catch (NSException *localException)
         {
             NSLog(@"Error in VDKQueue watcherThread: %@", localException);
         }
     }
     
-	// Close our kqueue's file descriptor
-	if(close(theFD) == -1) {
-       NSLog(@"VDKQueue watcherThread: Couldn't close main kqueue (%d)", errno); 
+    // Close our kqueue's file descriptor
+    if (close(theFD) == -1) {
+       NSLog(@"VDKQueue watcherThread: Couldn't close main kqueue (%d)", errno);
     }
     
     [notesToPost release];
     
 #if DEBUG_LOG_THREAD_LIFETIME
-	NSLog(@"watcherThread finished.");
+    NSLog(@"watcherThread finished.");
 #endif
-
 }
-
-
 
 
 
 
 #pragma mark -
 #pragma mark PUBLIC METHODS
-#pragma -----------------------------------------------------------------------------------------------------------------------------------------------------
+#pragma -----------------------------------------------------------------------
 
 
 - (void) addPath:(NSString *)aPath
@@ -400,14 +389,14 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
     [aPath retain];
     
     @synchronized(self)
-	{
-		VDKQueuePathEntry *entry = [_watchedPathEntries objectForKey:aPath];
+    {
+        VDKQueuePathEntry *entry = [_watchedPathEntries objectForKey:aPath];
         
         // Remove it only if we're watching it.
         if (entry) {
             [_watchedPathEntries removeObjectForKey:aPath];
         }
-	}
+    }
     
     [aPath release];
 }
@@ -435,7 +424,4 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 }
 
 
-
-
 @end
-


### PR DESCRIPTION
Unifying the usage of tabs and spaces using Xcode defaults: **cmd+a** → **cmd+x** → **cmd+v**