### PR TITLE
Don't poll every second for kevents

### DIFF
--- a/VDKQueue.h
+++ b/VDKQueue.h
@@ -29,6 +29,7 @@
 //
 //      VDKQueue is also simplified. The option to use it as a singleton is removed. You simply alloc/init an instance and add paths you want to
 //      watch. Your objects can be alerted to changes either by notifications or by a delegate method (or both). See below. 
+//      When you're done with the object, call stopWatching (to release the background thread), then release.
 //
 //      It also fixes several bugs. For one, it won't crash if it can't create a file descriptor to a file you ask it to watch. (By default, an OS X process can only
 //      have about 3,000 file descriptors open at once. If you hit that limit, UKKQueue will crash. VDKQueue will not.)
@@ -139,6 +140,7 @@ extern NSString * VDKQueueAccessRevocationNotification;
 - (void) removePath:(NSString *)aPath;
 - (void) removeAllPaths;
 
+- (void) stopWatching;                                              // You must call this when you release the VDKQueue object
 
 - (NSUInteger) numberOfWatchedPaths;                                //  Returns the number of paths that this VDKQueue instance is actively watching.
 

--- a/VDKQueue.h
+++ b/VDKQueue.h
@@ -124,7 +124,7 @@ extern NSString * VDKQueueAccessRevocationNotification;
 @private
     int						_coreQueueFD;                           // The actual kqueue ID (Unix file descriptor).
 	NSMutableDictionary    *_watchedPathEntries;                    // List of VDKQueuePathEntries. Keys are NSStrings of the path that each VDKQueuePathEntry is for.
-    BOOL                    _keepWatcherThreadRunning;              // Set to NO to cancel the thread that watches _coreQueueFD for kQueue events
+    BOOL                    _keepWatcherThreadRunning;              // Keeps track of whether the thread is running or not.
 }
 
 

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -431,6 +431,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
     {
         // Shut down the thread that's scanning for kQueue events
         kevent(_coreQueueFD, &(struct kevent){0, EVFILT_USER, EV_ENABLE, NOTE_TRIGGER, 0, NULL}, 1, NULL, 0, &(struct timespec){0,0});
+        _keepWatcherThreadRunning = NO;
 
         // Do this to close all the open file descriptors for files we're watching
         [_watchedPathEntries removeAllObjects];

--- a/VDKQueue.m
+++ b/VDKQueue.m
@@ -194,6 +194,8 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 			{
 				_keepWatcherThreadRunning = YES;
 				[NSThread detachNewThreadSelector:@selector(watcherThread:) toTarget:self withObject:nil];
+				// register a custom event that we will trigger to stop the thread
+				kevent(_coreQueueFD, &(struct kevent){0, EVFILT_USER, EV_ADD, NOTE_FFNOP, 0, NULL}, 1, NULL, 0, &nullts);
 			}
         }
         
@@ -212,7 +214,8 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 {
     int					n;
     struct kevent		ev;
-    struct timespec     timeout = { 1, 0 };     // 1 second timeout. Should be longer, but we need this thread to exit when a kqueue is dealloced, so 1 second timeout is quite a while to wait.
+    // no timeout needed. Instead of polling every second, we can pass NULL to wait indefinitely
+    // for vnode events or for an EVFILT_USER event to stop the thread.
 	int					theFD = _coreQueueFD;	// So we don't have to risk accessing iVars when the thread is terminated.
     
     NSMutableArray      *notesToPost = [[NSMutableArray alloc] initWithCapacity:5];
@@ -221,11 +224,14 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
 	NSLog(@"watcherThread started.");
 #endif
 	
-    while(_keepWatcherThreadRunning)
+    while(1)
     {
         @try 
         {
-            n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
+            n = kevent(theFD, NULL, 0, &ev, 1, NULL);
+            if (ev.filter == EVFILT_USER) {
+            	break;
+            }
             if (n > 0)
             {
                 //NSLog( @"KEVENT returned %d", n );
@@ -424,7 +430,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
     @synchronized(self)
     {
         // Shut down the thread that's scanning for kQueue events
-        _keepWatcherThreadRunning = NO;
+        kevent(_coreQueueFD, &(struct kevent){0, EVFILT_USER, EV_ENABLE, NOTE_TRIGGER, 0, NULL}, 1, NULL, 0, &(struct timespec){0,0});
 
         // Do this to close all the open file descriptors for files we're watching
         [_watchedPathEntries removeAllObjects];


### PR DESCRIPTION
In the watcher thread there is this comment:

> struct timespec timeout = { 1, 0 }; // 1 second timeout. Should be longer, but we need this thread to exit when a kqueue is dealloced, so 1 second timeout is quite a while to wait.

Polling kqueue once a second is inefficient and kind of seems to defeat the purpose of using kqueue in the first place. The correct way to do this is to basically send a signal telling the thread to terminate. I believe the method here (see the second commit in this pull request) takes care of this, by registering for, then triggering a "user" event.

Hopefully this is useful for someone out there!

(@Coeur I realize this repo isn't maintained anymore, but it's easier for me to post this here than having to clone the entire source of Transmission)